### PR TITLE
Add a navigation bar to the header

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -5,6 +5,20 @@ module.exports = {
     title: `Syracuse.io`,
     description: `Your local developer community.`,
     author: `@syracuseio`,
+    menuLinks:[
+      {
+        name:'Community',
+        link:'/community'
+      },
+      {
+        name:'Groups',
+        link:'/groups'
+      },
+      {
+        name:'Resources',
+        link:'/resources'
+      }
+    ],
   },
   plugins: [
     `gatsby-plugin-react-helmet`,

--- a/src/components/header.js
+++ b/src/components/header.js
@@ -1,42 +1,69 @@
+import React from 'react'
+import styled from 'styled-components'
+
 import { Link } from 'gatsby'
 import PropTypes from 'prop-types'
-import React from 'react'
 
-const Header = ({ siteTitle }) => (
-  <div
-    style={{
-      background: `rebeccapurple`,
-      marginBottom: `1.45rem`,
-    }}
-  >
-    <div
-      style={{
-        margin: `0 auto`,
-        maxWidth: 960,
-        padding: `1.45rem 1.0875rem`,
-      }}
-    >
-      <h1 style={{ margin: 0 }}>
-        <Link
-          to="/"
-          style={{
-            color: `white`,
-            textDecoration: `none`,
-          }}
-        >
-          {siteTitle}
-        </Link>
-      </h1>
-    </div>
-  </div>
+const Nav = styled.nav`
+  background-color: #1B1B1B;
+  border-bottom: 2px solid #474747;
+  padding: 0 20px;
+  font-size: 12px;
+  min-height: 50px;
+  margin-bottom: 20px;
+
+  a {
+    text-decoration: none;
+    font-weight: 700;
+    color: #F0F0F0;
+  }
+`
+
+const NavList = styled.ul`
+  display: flex;
+  margin: 0;
+  list-style: none;
+  letter-spacing: 1px;
+`
+
+const BrandItem = styled.li`
+  padding: 20px 15px;
+  height: 50px;
+  font-size: 18px;
+  line-height: 20px;
+  margin-right: auto;
+`
+
+
+const MenuItem = styled.li`
+  text-transform: uppercase;
+  padding: 20px 15px;
+  line-height: 20px;
+  height: 50px;
+`
+
+const Header = ({ siteTitle, menuLinks }) => (
+<Nav>
+  <NavList role="navigation">
+    <BrandItem><Link to="/">Syracuse.io</Link></BrandItem>
+    {
+      menuLinks.map(link =>
+        <MenuItem key={link.name}>
+          <Link to={link.link}>{link.name}</Link>
+        </MenuItem>)
+    }
+  </NavList>
+</Nav>
 )
 
 Header.propTypes = {
   siteTitle: PropTypes.string,
+  menuLinks: PropTypes.string,
 }
 
 Header.defaultProps = {
   siteTitle: ``,
+  menuLinks: [],
 }
 
 export default Header

--- a/src/components/layout.css
+++ b/src/components/layout.css
@@ -1,5 +1,5 @@
 html {
-  font-family: sans-serif;
+  font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
 }
@@ -183,7 +183,7 @@ textarea {
   font: inherit;
 }
 html {
-  font: 112.5%/1.45em georgia, serif;
+  font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
   box-sizing: border-box;
   overflow-y: scroll;
 }
@@ -198,7 +198,7 @@ html {
 }
 body {
   color: hsla(0, 0%, 0%, 0.8);
-  font-family: georgia, serif;
+  font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
   font-weight: normal;
   word-wrap: break-word;
   font-kerning: normal;

--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -34,13 +34,17 @@ const Layout = ({ children }) => (
         site {
           siteMetadata {
             title
+            menuLinks {
+              name
+              link
+            }
           }
         }
       }
     `}
     render={data => (
       <LayoutContainer>
-        <Header siteTitle={data.site.siteMetadata.title} />
+        <Header siteTitle={data.site.siteMetadata.title} menuLinks={data.site.siteMetadata.menuLinks} />
         <main>{children}</main>
         <Footer />
       </LayoutContainer>


### PR DESCRIPTION
closes #7 

This adds a basic navigation element to the header allowing easy navigation to the pages.  The style is based entirely on the existing syracuse.io header.