### PR TITLE
Upgrading relative links with gatsby-plugin-catch-links

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -46,6 +46,7 @@ module.exports = {
         extensions: [".mdx", ".md"]
       },
     },
+    'gatsby-plugin-catch-links',
     {
       resolve: `gatsby-source-meetup`,
       options: {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "gatsby-cli": "^2.4.8",
     "gatsby-image": "^2.0.20",
     "gatsby-mdx": "^0.3.3",
+    "gatsby-plugin-catch-links": "^2.0.9",
     "gatsby-plugin-manifest": "^2.0.9",
     "gatsby-plugin-react-helmet": "^3.0.2",
     "gatsby-plugin-sharp": "^2.0.14",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5239,6 +5239,14 @@ gatsby-mdx@^0.3.3:
     unist-util-remove "^1.0.1"
     unist-util-visit "^1.4.0"
 
+gatsby-plugin-catch-links@^2.0.9:
+  version "2.0.9"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-catch-links/-/gatsby-plugin-catch-links-2.0.9.tgz#1fd5bf02a7f997f7b36c4e0c28b689f0c3d92726"
+  integrity sha512-0I78VTwy9GJkh8nEt33VASo/cvBmDtdChoISQ+U0Pio5pXEXT2RQIesuHwcm4pXG/VRDVnEYxa95PLUccW5vFg==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    escape-string-regexp "^1.0.5"
+
 gatsby-plugin-manifest@^2.0.9:
   version "2.0.12"
   resolved "https://registry.yarnpkg.com/gatsby-plugin-manifest/-/gatsby-plugin-manifest-2.0.12.tgz#7e25f8997ea690969eeaa010a2d111209282f2ce"


### PR DESCRIPTION
Close #11.

[gatsby-plugin-catch-links](https://www.gatsbyjs.org/packages/gatsby-plugin-catch-links) will transform any relative link to be enhanced with the Gatsby `<Link/>` tag.