### PR TITLE
render upcoming meetup description as html

### DIFF
--- a/src/components/UpcomingMeetups.js
+++ b/src/components/UpcomingMeetups.js
@@ -81,7 +81,7 @@ function UpcomingMeetups() {
                     <a href={node.link}>{node.name}</a>
                   </h4>
                   <blockquote>
-                    <p>{description}</p>
+                    <p dangerouslySetInnerHTML={{ __html: description }} />
                   </blockquote>
                   {idx !== meetups.length - 1 && <hr />}
                 </EventContainer>


### PR DESCRIPTION
Closes #39.

Now the description will be rendered as HTML rather than an HTML string