### PR TITLE
feat: Updating styling for group cards

### DIFF
--- a/src/components/GlobalStyle.js
+++ b/src/components/GlobalStyle.js
@@ -103,14 +103,13 @@ const GlobalStyle = createGlobalStyle`
   }
 
   .label {
-    padding: 0.2em 0.6em 0.3em;
+    padding: 4px;
     color: white;
-    font-size: 14px;
-    border-radius: 0.25em;
-    height: 26px;
-    display: flex;
-    justify-content: center;
-    align-items: center;
+    font-size: 12px;
+    position: absolute;
+    bottom: -12px;
+    right: 10px;
+    box-shadow: 0px 1px 2px rgba(0,0,0,0.12), 0px 2px 4px rgba(0,0,0,0.24);
 
     &.hackathon {
       background: #d9534f;

--- a/src/components/groupCards.js
+++ b/src/components/groupCards.js
@@ -1,36 +1,18 @@
 import React from 'react'
-import { StaticQuery, graphql, Link } from 'gatsby'
+import { useStaticQuery, graphql, Link } from 'gatsby'
 import Img from 'gatsby-image'
 import styled from 'styled-components'
 
 const GroupContainer = styled.div`
-  border: 1px solid #ddd;
   border-radius: 4px;
-  box-shadow: 0 1px 1px rgba(0, 0, 0, 0.05);
+  box-shadow: 0 20px 80px rgba(0, 0, 0, 0.16);
   display: flex;
   flex-direction: column;
-  margin-bottom: 30px;
+  transition: transform 200ms ease-in-out, box-shadow 200ms ease-in-out;
 
-  div.gatsby-image-wrapper {
-    height: 175px;
-    margin-bottom: 10px;
-    border-top-left-radius: 4px;
-    border-top-right-radius: 4px;
-  }
-
-  img {
-    object-fit: cover;
-  }
-
-  header {
-    padding: 0 10px;
-    display: flex;
-    justify-content: space-between;
-    margin-bottom: 10px;
-  }
-
-  header b {
-    font-size: 18px;
+  &:hover {
+    transform: translateY(-4px);
+    box-shadow: 0 20px 80px rgba(0, 0, 0, 0.24);
   }
 
   p {
@@ -41,25 +23,45 @@ const GroupContainer = styled.div`
     margin-top: 0;
     margin-bottom: 20px;
   }
+`
 
-  .bottom {
-    background: #f5f5f5;
-    padding: 7px;
-    display: flex;
-    justify-content: flex-end;
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
+const LearnMoreLink = styled(Link)`
+  background: #f5f5f5;
+  color: #7a7a7a;
+  padding: 7px;
+  text-align: center;
+  font-weight: 200;
+  border-bottom-left-radius: 4px;
+  border-bottom-right-radius: 4px;
+
+  &:hover {
+    text-decoration: none;
+  }
+`
+
+const Header = styled(Link)`
+  display: block;
+  height: 200px;
+  position: relative;
+
+  div.gatsby-image-wrapper {
+    height: 200px;
+    margin-bottom: 10px;
+    border-top-left-radius: 4px;
+    border-top-right-radius: 4px;
   }
 
-  .bottom a {
-    background: white;
-    border: 1px solid #ddd;
-    padding: 2px 8px;
-    margin: 2px;
-    border-radius: 2px;
-    color: inherit;
-    text-decoration: none;
-    font-size: 14px;
+  img {
+    object-fit: cover;
+  }
+
+  b {
+    font-size: 24px;
+    color: white;
+    text-shadow: 0px 1px 2px rgba(0, 0, 0, 0.24);
+    position: absolute;
+    bottom: 10px;
+    padding: 0 10px;
   }
 `
 
@@ -68,76 +70,80 @@ const GroupGrid = styled.div`
   grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
   grid-gap: 30px;
   margin: 20px 10px;
+  margin-bottom: 40px;
+`
+
+const Tint = styled.div`
+  background-color: black;
+  opacity: 0.25;
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  top: 0;
+  border-top-left-radius: 4px;
+  border-top-right-radius: 4px;
 `
 
 const GroupCards = () => {
-  return (
-    <StaticQuery
-      query={graphql`
-        {
-          allMdx(
-            filter: { fileAbsolutePath: { regex: "/src/content/groups/" } }
-            sort: { fields: frontmatter___title }
-          ) {
-            edges {
-              node {
-                fields {
-                  slug
-                }
-                frontmatter {
-                  title
-                  group
-                  summary
-                  groupType
-                  imgAlt
-                  img {
-                    childImageSharp {
-                      fluid(maxWidth: 500) {
-                        ...GatsbyImageSharpFluid
-                      }
-                    }
+  const data = useStaticQuery(graphql`
+    {
+      allMdx(
+        filter: { fileAbsolutePath: { regex: "/src/content/groups/" } }
+        sort: { fields: frontmatter___title }
+      ) {
+        edges {
+          node {
+            fields {
+              slug
+            }
+            frontmatter {
+              title
+              group
+              summary
+              groupType
+              imgAlt
+              img {
+                childImageSharp {
+                  fluid(maxWidth: 500) {
+                    ...GatsbyImageSharpFluid
                   }
                 }
               }
             }
           }
         }
-      `}
-      render={data => {
-        let groups = data.allMdx.edges.filter(
-          edge => edge.node.fields.slug !== '/groups/'
-        )
+      }
+    }
+  `)
 
+  let groups = data.allMdx.edges.filter(
+    edge => edge.node.fields.slug !== '/groups/'
+  )
+
+  return (
+    <GroupGrid>
+      {groups.map(({ node: group }, idx) => {
         return (
-          <GroupGrid>
-            {groups.map(({ node: group }, idx) => {
-              return (
-                <GroupContainer key={`group-${idx}`}>
-                  {group.frontmatter.img && (
-                    <Link to={group.fields.slug}>
-                      <Img
-                        fluid={group.frontmatter.img.childImageSharp.fluid}
-                        alt={group.frontmatter.imgAlt}
-                      />
-                    </Link>
-                  )}
-                  <header>
-                    <b>{group.frontmatter.title}</b>
-                    <span className={`${group.frontmatter.groupType} label`}>
-                      {group.frontmatter.groupType}
-                    </span>
-                  </header>
-                  <p>{group.frontmatter.summary}</p>
-                  <div className="bottom">
-                    <Link to={group.fields.slug}>Learn More</Link>
-                  </div>
-                </GroupContainer>
-              )
-            })}
-          </GroupGrid>
+          <GroupContainer key={`group-${idx}`}>
+            {group.frontmatter.img && (
+              <Header to={group.fields.slug}>
+                <Img
+                  fluid={group.frontmatter.img.childImageSharp.fluid}
+                  alt={group.frontmatter.imgAlt}
+                />
+                <Tint />
+                <b>{group.frontmatter.title}</b>
+                <span className={`${group.frontmatter.groupType} label`}>
+                  {group.frontmatter.groupType}
+                </span>
+              </Header>
+            )}
+            <p>{group.frontmatter.summary}</p>
+            <LearnMoreLink to={group.fields.slug}>Learn More</LearnMoreLink>
+          </GroupContainer>
         )
-      }}
-    />
+      })}
+    </GroupGrid>
   )
 }
 


### PR DESCRIPTION
Updated the style for the group cards found on the `/groups/` page

## Preview

The old design is on the left. New ones are on the right.

![Screen Shot 2019-06-15 at 5 15 48 PM](https://user-images.githubusercontent.com/3685876/59556644-aa33d980-8f93-11e9-93fa-9abf9a4d5f93.png)
