### PR TITLE
pull down meetup data locally

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -59,16 +59,6 @@ module.exports = {
       },
     },
     'gatsby-plugin-catch-links',
-    {
-      resolve: `gatsby-source-meetup`,
-      options: {
-        key: process.env.MEETUP_API_KEY,
-        groupUrlName: `Syracuse-Software-Development-Meetup`,
-        status: `upcoming,past`,
-        desc: `true`,
-        page: 200,
-      },
-    },
     `gatsby-plugin-sharp`,
     {
       resolve: `gatsby-plugin-manifest`,

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -29,7 +29,6 @@ exports.sourceNodes = ({ actions }) => {
       description: String
       meetup_group: String
       display_name: String
-      rsvp_count: String
       link: String
     }
   `
@@ -66,12 +65,6 @@ exports.onCreateNode = ({
 
     let status = today.diff(eventMoment) >= 0 ? `past` : `upcoming`
 
-    actions.createNodeField({
-      node,
-      name: `status`,
-      value: status,
-    })
-
     let nodeId = createNodeId(`event-j-${node.id}`)
     let data = {
       name: node.name,
@@ -98,7 +91,7 @@ exports.onCreateNode = ({
     actions.createNode(nodeData)
   }
 
-  if (node.internal.type === `MeetupEvent`) {
+  if (node.internal.type === `MeetupJson`) {
     let meetupGroup
     let displayName
 
@@ -114,17 +107,30 @@ exports.onCreateNode = ({
       meetupGroup = 'other'
     }
 
+    let today = moment()
+    let eventMoment = moment(
+      `${node.local_date} ${node.local_time}`,
+      'YYYY-MM-DD HH:mm'
+    )
+
+    // console.log(node)
+
+    let status = today.diff(eventMoment) >= 0 ? `past` : `upcoming`
+
+    if (status !== 'upcoming' && status !== 'past') {
+      console.log(JSON.stringify({ s: status }))
+    }
+
     let nodeId = createNodeId(`event-m-${node.id}`)
     let data = {
       name: node.name,
-      status: node.status,
+      status: status,
       local_date: node.local_date,
       local_time: node.local_time,
       description: node.description,
       link: node.link,
       meetup_group: meetupGroup,
       display_name: displayName,
-      rsvp_count: node.yes_rsvp_count,
     }
     const nodeContent = JSON.stringify(data)
     const nodeData = Object.assign({}, data, {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "gatsby-plugin-sitemap": "^2.1.0",
     "gatsby-plugin-styled-components": "^3.0.7",
     "gatsby-source-filesystem": "^2.0.36",
-    "gatsby-source-meetup": "^0.0.1",
     "gatsby-transformer-json": "^2.1.11",
     "gatsby-transformer-sharp": "^2.1.19",
     "moment": "^2.24.0",

--- a/src/data/events.json
+++ b/src/data/events.json
@@ -1,5 +1,14 @@
 [
   {
+    "name": "Hack Upstate XIV",
+    "local_date": "2019-10-05",
+    "local_time": "12:00",
+    "link": "https://hackupstate.com/events/xiv",
+    "description": "Hack Upstate organizes weekend hackathons twice a year (i.e., Fall & Spring) where developers, designers, engineers and innovators from across Upstate New York come to Syracuse, NY, to share ideas, form teams, build projects, and win awesome prizes in 24 hours",
+    "meetup_group": "hack_upstate",
+    "display_name": "Hack Upstate"
+  },
+  {
     "name": "Hack Upstate XIII",
     "local_date": "2019-04-06",
     "local_time": "12:00",

--- a/src/data/meetup.json
+++ b/src/data/meetup.json
@@ -1,0 +1,737 @@
+[
+  {
+    "name": "Developer Happy Hour! 🍻 ",
+    "local_date": "2018-01-31",
+    "local_time": "17:15",
+    "link": "https://www.meetup.com/Syracuse-Software-Development-Meetup/events/247277585/",
+    "description": "<p>• What we'll do<br/>Hey! Welcome to the group! As part of the launch of the Syracuse Software Development Meetup, you're invited to come meet other devs for a casual after work Happy Hour, this Wednesday, at 5:15 - 7pm at Shaughnessy’s Irish Pub on Warren St, Downtown Syracuse (Attached to Hotel Syracuse). This event is open to developers of all skill levels And FWIW, this is not a \" formal networking event\". Please no recruiters or people seeking \"Technical cofounders\" for their _\"great startup idea\"_ thank you. 🍻</p> <p>Anyway, it's a happy hour, come out and say hello!</p> <p>• What to bring</p> <p>• Important to know<br/>Street parking is generally available, but there’s a garage on Harrison &amp; Warren.</p> "
+  },
+  {
+    "name": "OpenHack: Code together, on anything.",
+    "local_date": "2018-02-13",
+    "local_time": "18:00",
+    "link": "https://www.meetup.com/Syracuse-Software-Development-Meetup/events/gdqxgpyxdbrb/",
+    "description": "<p>• What we'll do<br/>OpenHack is a casual social coding meetup with a simple purpose: Code together, on anything.</p> <p>We welcome local developers and designers of all skill levels, interests, ages genders, you-name-it to get together to write code or push pixels. We’ll provide good food, good people, and creative energy.</p> <p>Here’s how OpenHack works:</p> <p>* You can hack on anything! Any language, framework, public/open-source, personal projects, client work… anything!<br/>* You don’t have to have an idea to hack on, you can come join someone else<br/>* We’ll kick things off with a quick round of introductions, to say who you are, what you’re working on, and if you’d like help with your idea<br/>* Food and drinks will be provided<br/>* Feel free to join us - bring a laptop, a project, and a friend!</p> <p>See more at <a href=\"http://openhacksyr.com\" class=\"linkified\">http://openhacksyr.com</a></p> <p>• What to bring<br/>A laptop if you're bringing a project, but not required</p> <p>• Important to know<br/>Please review our Code of Conduct before attending: <a href=\"http://openhacksyr.com/code_of_conduct/\" class=\"linkified\">http://openhacksyr.com/code_of_conduct/</a></p> "
+  },
+  {
+    "name": "Syracuse JavaScript Meetup | Current Topic: NodeJS",
+    "local_date": "2018-02-20",
+    "local_time": "18:00",
+    "link": "https://www.meetup.com/Syracuse-Software-Development-Meetup/events/247433382/",
+    "description": "<p>• What we'll do<br/>We are a group dedicated to discussing and working with the JavaScript programming language.</p> <p>Currently we meet the third Tuesday of each month, and each event has both a learning and interactive portion. Whether you’re an experienced JavaScript programmer or just getting started, we welcome and encourage all proficiency levels.</p> <p>This month we'll be exploring the basics of NodeJS. If you're not familiar, come learn something new! Already a pro? Awesome! We can use some mentors to help out with questions.</p> <p>• What to bring<br/>laptop</p> <p>• Important to know<br/>Harassment-free meetup, regardless of topic.</p> "
+  },
+  {
+    "name": "OpenHack: Code together, on anything.",
+    "local_date": "2018-03-13",
+    "local_time": "18:00",
+    "link": "https://www.meetup.com/Syracuse-Software-Development-Meetup/events/gdqxgpyxfbrb/",
+    "description": "<p>• What we'll do<br/>OpenHack is a casual social coding meetup with a simple purpose: Code together, on anything.</p> <p>We welcome local developers and designers of all skill levels, interests, ages genders, you-name-it to get together to write code or push pixels. We’ll provide good food, good people, and creative energy.</p> <p>Here’s how OpenHack works:</p> <p>* You can hack on anything! Any language, framework, public/open-source, personal projects, client work… anything!<br/>* You don’t have to have an idea to hack on, you can come join someone else<br/>* We’ll kick things off with a quick round of introductions, to say who you are, what you’re working on, and if you’d like help with your idea<br/>* Food and drinks will be provided<br/>* Feel free to join us - bring a laptop, a project, and a friend!</p> <p>See more at <a href=\"http://openhacksyr.com\" class=\"linkified\">http://openhacksyr.com</a></p> <p>• What to bring<br/>A laptop if you're bringing a project, but not required</p> <p>• Important to know<br/>Please review our Code of Conduct before attending: <a href=\"http://openhacksyr.com/code_of_conduct/\" class=\"linkified\">http://openhacksyr.com/code_of_conduct/</a></p> "
+  },
+  {
+    "name": "Syracuse JavaScript Meetup | Current Topic: Asynchronous JavaScript",
+    "local_date": "2018-03-20",
+    "local_time": "18:00",
+    "link": "https://www.meetup.com/Syracuse-Software-Development-Meetup/events/nftglpyxfbbc/",
+    "description": "<p>• What we'll do<br/>We are a group dedicated to discussing and working with the JavaScript programming language.</p> <p>Currently we meet the third Tuesday of each month, and each event has both a learning and interactive portion. Whether you’re an experienced JavaScript programmer or just getting started, we welcome and encourage all proficiency levels.</p> <p>Each month we'll be exploring the \"Current Topic\" referenced in the Meetup title. If you're not familiar with the topic, come learn something new! Already a pro? Awesome! We can use some mentors to help out with questions.</p> <p>• What to bring<br/>Laptop</p> <p>• Important to know<br/>Harassment-free meetup, regardless of topic</p> "
+  },
+  {
+    "name": "Happy Hour hosted by Upstate Interactive and Euphony! 🍻",
+    "local_date": "2018-04-05",
+    "local_time": "16:30",
+    "link": "https://www.meetup.com/Syracuse-Software-Development-Meetup/events/249394375/",
+    "description": "<p>Stop by for free beer and snacks, and meet some of the great people and companies at the Tech Garden.</p> <p>Where: Upstate Interactive and Euphony's office at The Tech Garden<br/>When: This Thursday 4:30 PM - 6 PM<br/>Hosted By: Upstate Interactive and Euphony<br/>Sponsored By: The Tech Garden<br/>Featuring: Free Beer, Free Snacks, and more<br/>Why: Fun!</p> "
+  },
+  {
+    "name": "OpenHack: Code together, on anything.",
+    "local_date": "2018-04-10",
+    "local_time": "18:00",
+    "link": "https://www.meetup.com/Syracuse-Software-Development-Meetup/events/gdqxgpyxgbnb/",
+    "description": "<p>• What we'll do<br/>OpenHack is a casual social coding meetup with a simple purpose: Code together, on anything.</p> <p>We welcome local developers and designers of all skill levels, interests, ages genders, you-name-it to get together to write code or push pixels. We’ll provide good food, good people, and creative energy.</p> <p>Here’s how OpenHack works:</p> <p>* You can hack on anything! Any language, framework, public/open-source, personal projects, client work… anything!<br/>* You don’t have to have an idea to hack on, you can come join someone else<br/>* We’ll kick things off with a quick round of introductions, to say who you are, what you’re working on, and if you’d like help with your idea<br/>* Food and drinks will be provided<br/>* Feel free to join us - bring a laptop, a project, and a friend!</p> <p>See more at <a href=\"http://openhacksyr.com\" class=\"linkified\">http://openhacksyr.com</a></p> <p>• What to bring<br/>A laptop if you're bringing a project, but not required</p> <p>• Important to know<br/>Please review our Code of Conduct before attending: <a href=\"http://openhacksyr.com/code_of_conduct/\" class=\"linkified\">http://openhacksyr.com/code_of_conduct/</a></p> "
+  },
+  {
+    "name": "Syracuse JavaScript Meetup | Topic: General JS",
+    "local_date": "2018-04-17",
+    "local_time": "18:00",
+    "link": "https://www.meetup.com/Syracuse-Software-Development-Meetup/events/nftglpyxgbwb/",
+    "description": "<p>• What we'll do<br/>We are a group dedicated to discussing and working with the JavaScript programming language.</p> <p>Currently we meet the third Tuesday of each month, and each event has both a learning and interactive portion. Whether you’re an experienced JavaScript programmer or just getting started, we welcome and encourage all proficiency levels.</p> <p>Each month we'll be exploring the \"Current Topic\" referenced in the Meetup title. If you're not familiar with the topic, come learn something new! Already a pro? Awesome! We can use some mentors to help out with questions.</p> <p>• What to bring<br/>Laptop</p> <p>• Important to know<br/>Harassment-free meetup, regardless of topic</p> "
+  },
+  {
+    "name": "Developer Happy Hour! 🍻 ",
+    "local_date": "2018-04-26",
+    "local_time": "17:15",
+    "link": "https://www.meetup.com/Syracuse-Software-Development-Meetup/events/249566139/",
+    "description": "<p>• What we'll do<br/>`/dev/drinks` is a quarterly happy hour for local devs to get together and mingle at a local establishment.</p> <p>Come meet other devs for a casual after work Happy Hour, at 5:15 - 7pm at Shaughnessy’s Irish Pub on Warren St, Downtown Syracuse (Attached to Hotel Syracuse).</p> <p>This event is open to developers of all skill levels And FWIW, this is not a  formal networking event. Please no recruiters or people seeking \"Technical cofounders\" for their _\"great startup idea\"_ thank you. 🍻</p> <p>Anyway, it's a happy hour, come out and say hello!</p> <p>• What to bring</p> <p>• Important to know<br/>Street parking is generally available, but there’s a garage on Harrison &amp; Warren.</p> "
+  },
+  {
+    "name": "OpenHack: Code together, on anything.",
+    "local_date": "2018-05-08",
+    "local_time": "18:00",
+    "link": "https://www.meetup.com/Syracuse-Software-Development-Meetup/events/gdqxgpyxhblb/",
+    "description": "<p>• What we'll do<br/>OpenHack is a casual social coding meetup with a simple purpose: Code together, on anything.</p> <p>We welcome local developers and designers of all skill levels, interests, ages genders, you-name-it to get together to write code or push pixels. We’ll provide good food, good people, and creative energy.</p> <p>Here’s how OpenHack works:</p> <p>* You can hack on anything! Any language, framework, public/open-source, personal projects, client work… anything!<br/>* You don’t have to have an idea to hack on, you can come join someone else<br/>* We’ll kick things off with a quick round of introductions, to say who you are, what you’re working on, and if you’d like help with your idea<br/>* Food and drinks will be provided<br/>* Feel free to join us - bring a laptop, a project, and a friend!</p> <p>See more at <a href=\"http://openhacksyr.com\" class=\"linkified\">http://openhacksyr.com</a></p> <p>• What to bring<br/>A laptop if you're bringing a project, but not required</p> <p>• Important to know<br/>Please review our Code of Conduct before attending: <a href=\"http://openhacksyr.com/code_of_conduct/\" class=\"linkified\">http://openhacksyr.com/code_of_conduct/</a></p> "
+  },
+  {
+    "name": "Syracuse JavaScript Meetup | Topic: Open JS Discussions",
+    "local_date": "2018-05-15",
+    "local_time": "18:00",
+    "link": "https://www.meetup.com/Syracuse-Software-Development-Meetup/events/nftglpyxhbtb/",
+    "description": "<p>• What we'll do<br/>We are a group dedicated to discussing and working with the JavaScript programming language.</p> <p>Currently we meet the third Tuesday of each month, and each event has both a learning and interactive portion. Whether you’re an experienced JavaScript programmer or just getting started, we welcome and encourage all proficiency levels.</p> <p>Each month we'll be exploring the \"Current Topic\" referenced in the Meetup title. If you're not familiar with the topic, come learn something new! Already a pro? Awesome! We can use some mentors to help out with questions.</p> <p>• What to bring<br/>Laptop</p> <p>• Important to know<br/>Harassment-free meetup, regardless of topic</p> "
+  },
+  {
+    "name": "OpenHack: Code together, on anything.",
+    "local_date": "2018-06-12",
+    "local_time": "18:00",
+    "link": "https://www.meetup.com/Syracuse-Software-Development-Meetup/events/gdqxgpyxjbqb/",
+    "description": "<p>• What we'll do<br/>OpenHack is a casual social coding meetup with a simple purpose: Code together, on anything.</p> <p>We welcome local developers and designers of all skill levels, interests, ages genders, you-name-it to get together to write code or push pixels. We’ll provide good food, good people, and creative energy.</p> <p>Here’s how OpenHack works:</p> <p>* You can hack on anything! Any language, framework, public/open-source, personal projects, client work… anything!<br/>* You don’t have to have an idea to hack on, you can come join someone else<br/>* We’ll kick things off with a quick round of introductions, to say who you are, what you’re working on, and if you’d like help with your idea<br/>* Food and drinks will be provided<br/>* Feel free to join us - bring a laptop, a project, and a friend!</p> <p>See more at <a href=\"http://openhacksyr.com\" class=\"linkified\">http://openhacksyr.com</a></p> <p>• What to bring<br/>A laptop if you're bringing a project, but not required</p> <p>• Important to know<br/>Please review our Code of Conduct before attending: <a href=\"http://openhacksyr.com/code_of_conduct/\" class=\"linkified\">http://openhacksyr.com/code_of_conduct/</a></p> "
+  },
+  {
+    "name": "Syracuse JavaScript Meetup | Topic: Callbacks, Promises & Observables",
+    "local_date": "2018-06-19",
+    "local_time": "18:00",
+    "link": "https://www.meetup.com/Syracuse-Software-Development-Meetup/events/nftglpyxjbzb/",
+    "description": "<p>• What we'll do<br/>We are a group dedicated to discussing and working with the JavaScript programming language.</p> <p>Currently we meet the third Tuesday of each month, and each event has both a learning and interactive portion. Whether you’re an experienced JavaScript programmer or just getting started, we welcome and encourage all proficiency levels.</p> <p>Each month we'll be exploring the \"Current Topic\" referenced in the Meetup title. If you're not familiar with the topic, come learn something new! Already a pro? Awesome! We can use some mentors to help out with questions.</p> <p>• What to bring<br/>Laptop</p> <p>• Important to know<br/>Harassment-free meetup, regardless of topic</p> "
+  },
+  {
+    "name": "Developer Happy Hour! 🍻 ",
+    "local_date": "2018-06-28",
+    "local_time": "17:30",
+    "link": "https://www.meetup.com/Syracuse-Software-Development-Meetup/events/252033635/",
+    "description": "<p>/dev/drinks is a casual after work Happy Hour at Shaughnessy’s Irish Pub on Warren St, Downtown Syracuse (Attached to Hotel Syracuse).</p> <p>This event is for developers of all skill levels And is not a Formal Networking Event. Please no recruiters or people seeking \"Technical cofounders\" for their _\"great startup idea\"_ thank you. 🍻</p> <p>Anyway, it's a happy hour. Come out and say hi!</p> <p><a href=\"https://syracuse.io/groups/dev_drinks/\" class=\"linkified\">https://syracuse.io/groups/dev_drinks/</a></p> "
+  },
+  {
+    "name": "OpenHack: Code together, on anything.",
+    "local_date": "2018-07-10",
+    "local_time": "18:00",
+    "link": "https://www.meetup.com/Syracuse-Software-Development-Meetup/events/gdqxgpyxkbnb/",
+    "description": "<p>• What we'll do<br/>OpenHack is a casual social coding meetup with a simple purpose: Code together, on anything.</p> <p>We welcome local developers and designers of all skill levels, interests, ages genders, you-name-it to get together to write code or push pixels. We’ll provide good food, good people, and creative energy.</p> <p>Here’s how OpenHack works:</p> <p>* You can hack on anything! Any language, framework, public/open-source, personal projects, client work… anything!<br/>* You don’t have to have an idea to hack on, you can come join someone else<br/>* We’ll kick things off with a quick round of introductions, to say who you are, what you’re working on, and if you’d like help with your idea<br/>* Food and drinks will be provided<br/>* Feel free to join us - bring a laptop, a project, and a friend!</p> <p>See more at <a href=\"http://openhacksyr.com\" class=\"linkified\">http://openhacksyr.com</a></p> <p>• What to bring<br/>A laptop if you're bringing a project, but not required</p> <p>• Important to know<br/>Please review our Code of Conduct before attending: <a href=\"http://openhacksyr.com/code_of_conduct/\" class=\"linkified\">http://openhacksyr.com/code_of_conduct/</a></p> "
+  },
+  {
+    "name": "Blockchain BaBBle",
+    "local_date": "2018-07-26",
+    "local_time": "17:30",
+    "link": "https://www.meetup.com/Syracuse-Software-Development-Meetup/events/252170902/",
+    "description": "<p>📢Announcement - Note to Virtual Audience - Jul 26, 2018</p> <p>We will be using Facebook Live instead of YouTube Live for technical reasons. Zoom as the event host has support for both, however, Facebook is the only one that is working.</p> <p>📢Announcement - Note to Virtual Audience - Jul 19, 2018</p> <p>YouTube Live Link Will Be Available Here...</p> <p>Bookmark this page and come back to it on the day of the event to get the YouTube Live URL.</p> <p>▶ Timing<br/>🕒5:30 - 🍻Welcome<br/>🕒6:00 - 🔈Speaker Babble<br/>🕒8:00 - 🏖️Hang Out</p> <p>▶ Speakers<br/>Ripple XRP Intelligence Suite - Mo Morsi, Dev Null Productions<br/>Truffle and React - Aaron Anderson, Web3Devs<br/>KittyHats - Dan Viau, Salina Labs<br/>OpenZeppelin - Doug Crescenzi, Upstate Interactive</p> <p>▶ Attendees (limit of 40 in-person attendees)<br/>🆓Free Attendance<br/>❓Ask Blockchain Developers Technical Questions<br/>🍻Free Food and Refreshments</p> <p>▶ Format<br/>🔈Speakers will give 15-20 minute talks followed by 20-30 minutes of Q+A.<br/>🔈All speakers will be giving technical and dive into the hard stuff. The fluff will be left for TED.<br/>🔈Talks will be broadcast on YouTube Live to a virtual audience from everywhere.</p> <p>▶ Interested in speaking?<br/>Check out the Speaker Info: <a href=\"https://bit.ly/2Mtl3ry\" class=\"linkified\">https://bit.ly/2Mtl3ry</a></p> "
+  },
+  {
+    "name": "Coffee & Code",
+    "local_date": "2018-08-05",
+    "local_time": "11:00",
+    "link": "https://www.meetup.com/Syracuse-Software-Development-Meetup/events/252706111/",
+    "description": "<p>Stop by for some Sunday morning coffee and coding!</p> <p>This is a general topic/networking event, nothing language-specific. Just bring yourself, something to code on, and enjoy some coffee with (new) friends!</p> <p>There's only room for about 10 or so people in the Community Room at this location, but there's more seating in the general cafe area as well. The Community Room has a large screen with a HDMI hookup and an array of outlets for plugging in, so it can be used for presenting/teaching/etc.</p> "
+  },
+  {
+    "name": "Intro to React Workshop",
+    "local_date": "2018-08-12",
+    "local_time": "11:00",
+    "link": "https://www.meetup.com/Syracuse-Software-Development-Meetup/events/253271455/",
+    "description": "<p>An introductory workshop to using the React JavaScript library for building user interfaces.</p> <p>---</p> <p>Firstly, what this workshop is NOT:<br/>- JavaScript tutorial (you should already have a good understanding of JS, ES6 syntax, etc.)<br/>- Node/Build toolchain tutorial (you should already know how to serve up content to a browser, start up a http-server, etc.)<br/>- External React library tutorial (We will not be covering topics like Redux, React Router, etc.)</p> <p>---</p> <p>In this workshop we'll explore the following:<br/>- What is React, and what is it used for?<br/>- Elements, Components, and how to compose and render them<br/>- Props (passing data around)<br/>- State (somewhat-persistent data within the client side application layer)<br/>- Event handling<br/>- JSX</p> <p>We'll be learning by \"doing\", which means each portion of the workshop will require the attendees to code along and/or work on exercises.</p> <p>The first portion will be \"bare-bones\" React to understand how it works, with the second half being more abstracted and in line with how the rest of the community typically works with the library.</p> <p>The goal is that by the end of the workshop you will have built a simple React application that touches on all of the subjects listed above.</p> <p>---</p> <p>What to bring:<br/>- Laptop</p> <p>Setup before arriving:<br/>- Optional: \"npm install -g http-server\"<br/>- Optional: Sign up for a free codesandbox.io account through GitHub</p> "
+  },
+  {
+    "name": "OpenHack: Code together, on anything.",
+    "local_date": "2018-08-14",
+    "local_time": "18:00",
+    "link": "https://www.meetup.com/Syracuse-Software-Development-Meetup/events/gdqxgpyxlbsb/",
+    "description": "<p>• What we'll do<br/>OpenHack is a casual social coding meetup with a simple purpose: Code together, on anything.</p> <p>We welcome local developers and designers of all skill levels, interests, ages genders, you-name-it to get together to write code or push pixels. We’ll provide good food, good people, and creative energy.</p> <p>Here’s how OpenHack works:</p> <p>* You can hack on anything! Any language, framework, public/open-source, personal projects, client work… anything!<br/>* You don’t have to have an idea to hack on, you can come join someone else<br/>* We’ll kick things off with a quick round of introductions, to say who you are, what you’re working on, and if you’d like help with your idea<br/>* Food and drinks will be provided<br/>* Feel free to join us - bring a laptop, a project, and a friend!</p> <p>See more at <a href=\"http://openhacksyr.com\" class=\"linkified\">http://openhacksyr.com</a></p> <p>• What to bring<br/>A laptop if you're bringing a project, but not required</p> <p>• Important to know<br/>Please review our Code of Conduct before attending: <a href=\"http://openhacksyr.com/code_of_conduct/\" class=\"linkified\">http://openhacksyr.com/code_of_conduct/</a></p> "
+  },
+  {
+    "name": "Syracuse JavaScript Meetup | Topic: JavaScript Components without a Framework",
+    "local_date": "2018-08-21",
+    "local_time": "18:00",
+    "link": "https://www.meetup.com/Syracuse-Software-Development-Meetup/events/nftglpyxlbcc/",
+    "description": "<p>Topic: JavaScript Components without a Framework<br/>Reference: <a href=\"https://medium.com/@peterbsmith/eb4f628929ae\" class=\"linkified\">https://medium.com/@peterbsmith/eb4f628929ae</a><br/>Presented by: Peter Smith</p> <p>• What we'll do<br/>We are a group dedicated to discussing and working with the JavaScript programming language.</p> <p>Currently we meet the third Tuesday of each month, and each event has both a learning and interactive portion. Whether you’re an experienced JavaScript programmer or just getting started, we welcome and encourage all proficiency levels.</p> <p>Each month we'll be exploring the \"Current Topic\" referenced in the Meetup title. If you're not familiar with the topic, come learn something new! Already a pro? Awesome! We can use some mentors to help out with questions.</p> <p>• What to bring<br/>Laptop</p> <p>• Important to know<br/>Harassment-free meetup, regardless of topic</p> "
+  },
+  {
+    "name": "Syracuse JavaScript Meetup | Topic: JavaScript Components without a Framework",
+    "local_date": "2018-08-28",
+    "local_time": "18:00",
+    "link": "https://www.meetup.com/Syracuse-Software-Development-Meetup/events/253989468/",
+    "description": "<p>Topic: JavaScript Components without a Framework<br/>Reference: <a href=\"https://medium.com/@peterbsmith/eb4f628929ae\" class=\"linkified\">https://medium.com/@peterbsmith/eb4f628929ae</a><br/>Presented by: Peter Smith</p> <p>• What we'll do<br/>We are a group dedicated to discussing and working with the JavaScript programming language.</p> <p>Currently we meet the third Tuesday of each month, and each event has both a learning and interactive portion. Whether you’re an experienced JavaScript programmer or just getting started, we welcome and encourage all proficiency levels.</p> <p>Each month we'll be exploring the \"Current Topic\" referenced in the Meetup title. If you're not familiar with the topic, come learn something new! Already a pro? Awesome! We can use some mentors to help out with questions.</p> <p>• What to bring<br/>Laptop</p> <p>• Important to know<br/>Harassment-free meetup, regardless of topic</p> "
+  },
+  {
+    "name": "OpenHack: Code together, on anything.",
+    "local_date": "2018-09-11",
+    "local_time": "18:00",
+    "link": "https://www.meetup.com/Syracuse-Software-Development-Meetup/events/gdqxgpyxmbpb/",
+    "description": "<p>• What we'll do<br/>OpenHack is a casual social coding meetup with a simple purpose: Code together, on anything.</p> <p>We welcome local developers and designers of all skill levels, interests, ages genders, you-name-it to get together to write code or push pixels. We’ll provide good food, good people, and creative energy.</p> <p>Here’s how OpenHack works:</p> <p>* You can hack on anything! Any language, framework, public/open-source, personal projects, client work… anything!<br/>* You don’t have to have an idea to hack on, you can come join someone else<br/>* We’ll kick things off with a quick round of introductions, to say who you are, what you’re working on, and if you’d like help with your idea<br/>* Food and drinks will be provided<br/>* Feel free to join us - bring a laptop, a project, and a friend!</p> <p>See more at <a href=\"http://openhacksyr.com\" class=\"linkified\">http://openhacksyr.com</a></p> <p>• What to bring<br/>A laptop if you're bringing a project, but not required</p> <p>• Important to know<br/>Please review our Code of Conduct before attending: <a href=\"http://openhacksyr.com/code_of_conduct/\" class=\"linkified\">http://openhacksyr.com/code_of_conduct/</a></p> "
+  },
+  {
+    "name": "Syracuse JavaScript Meetup | Topic: ES6+ Syntax + Challenges/Prizes!",
+    "local_date": "2018-09-18",
+    "local_time": "18:00",
+    "link": "https://www.meetup.com/Syracuse-Software-Development-Meetup/events/nftglpyxmbxb/",
+    "description": "<p>-=-=-=-=-=-=-=-=-=-=-=-=-<br/>Code challenges are back, and with new prizes! Everyone who participates has a chance to win, regardless of experience level!<br/>-=-=-=-=-=-=-=-=-=-=-=-=-</p> <p>• What we'll do<br/>We are a group dedicated to discussing and working with the JavaScript programming language.</p> <p>Currently we meet the third Tuesday of each month, and each event has both a learning and interactive portion. Whether you’re an experienced JavaScript programmer or just getting started, we welcome and encourage all proficiency levels.</p> <p>Each month we'll be exploring the \"Current Topic\" referenced in the Meetup title. If you're not familiar with the topic, come learn something new! Already a pro? Awesome! We can use some mentors to help out with questions.</p> <p>• What to bring<br/>Laptop</p> <p>• Important to know<br/>Harassment-free meetup, regardless of topic</p> "
+  },
+  {
+    "name": "Intro to React Workshop",
+    "local_date": "2018-09-23",
+    "local_time": "11:00",
+    "link": "https://www.meetup.com/Syracuse-Software-Development-Meetup/events/254095936/",
+    "description": "<p>An introductory workshop to using the React JavaScript library for building user interfaces.</p> <p>---</p> <p>Firstly, what this workshop is NOT:<br/>- JavaScript tutorial (you should already have a good understanding of JS, ES6 syntax, etc.)<br/>- Node/Build toolchain tutorial (you should already know how to serve up content to a browser, start up a http-server, etc.)<br/>- External React library tutorial (We will not be covering topics like Redux, React Router, etc.)</p> <p>---</p> <p>In this workshop we'll explore the following:<br/>- What is React, and what is it used for?<br/>- Elements, Components, and how to compose and render them<br/>- Props (passing data around)<br/>- State (somewhat-persistent data within the client side application layer)<br/>- Event handling<br/>- JSX</p> <p>We'll be learning by \"doing\", which means each portion of the workshop will require the attendees to code along and/or work on exercises.</p> <p>The first portion will be \"bare-bones\" React to understand how it works, with the second half being more abstracted and in line with how the rest of the community typically works with the library.</p> <p>The goal is that by the end of the workshop you will have built a simple React application that touches on all of the subjects listed above.</p> <p>---</p> <p>What to bring:<br/>- Laptop</p> <p>Setup before arriving:<br/>- Optional: \"npm install -g http-server\"<br/>- Optional: Sign up for a free codesandbox.io account through GitHub</p> "
+  },
+  {
+    "name": "React Components Workshop (Intermediate)",
+    "local_date": "2018-09-23",
+    "local_time": "13:45",
+    "link": "https://www.meetup.com/Syracuse-Software-Development-Meetup/events/254096341/",
+    "description": "<p>A workshop centered around creating and reusing React components.</p> <p>---</p> <p>*** IMPORTANT ***<br/>Firstly, what this workshop is NOT:<br/>- JavaScript tutorial (you should already have a good understanding of JS, ES6 syntax, etc.)<br/>- Introduction to React (you should understand the basics - or at minimum have already attended the Intro to React workshop)</p> <p>---</p> <p>In this workshop we'll explore the following:<br/>- Component types and composition<br/>- Props<br/>- State<br/>- Component lifecycle<br/>- Render props (time permitting)</p> <p>We'll be learning by doing, so we'll be coding along together as we explore each of the topics.</p> <p>The goal is that by the end of the workshop you will have a better understanding of how components are created and reused throughout a React application.</p> <p>---</p> <p>What to bring:<br/>- Laptop</p> <p>Setup before arriving:<br/>- Optional: Sign up for a free codesandbox.io account through GitHub</p> <p>Some helpful links to study beforehand:<br/>JavaScript classes - <a href=\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes\" class=\"linkified\">https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes</a></p> "
+  },
+  {
+    "name": "OpenHack: Code together, on anything.",
+    "local_date": "2018-10-09",
+    "local_time": "18:00",
+    "link": "https://www.meetup.com/Syracuse-Software-Development-Meetup/events/gdqxgpyxnbmb/",
+    "description": "<p>• What we'll do<br/>OpenHack is a casual social coding meetup with a simple purpose: Code together, on anything.</p> <p>We welcome local developers and designers of all skill levels, interests, ages genders, you-name-it to get together to write code or push pixels. We’ll provide good food, good people, and creative energy.</p> <p>Here’s how OpenHack works:</p> <p>* You can hack on anything! Any language, framework, public/open-source, personal projects, client work… anything!<br/>* You don’t have to have an idea to hack on, you can come join someone else<br/>* We’ll kick things off with a quick round of introductions, to say who you are, what you’re working on, and if you’d like help with your idea<br/>* Food and drinks will be provided<br/>* Feel free to join us - bring a laptop, a project, and a friend!</p> <p>See more at <a href=\"http://openhacksyr.com\" class=\"linkified\">http://openhacksyr.com</a></p> <p>• What to bring<br/>A laptop if you're bringing a project, but not required</p> <p>• Important to know<br/>Please review our Code of Conduct before attending: <a href=\"http://openhacksyr.com/code_of_conduct/\" class=\"linkified\">http://openhacksyr.com/code_of_conduct/</a></p> "
+  },
+  {
+    "name": "Intro to HTML & CSS - Library Workshop by Women in Coding",
+    "local_date": "2018-10-13",
+    "local_time": "10:00",
+    "link": "https://www.meetup.com/Syracuse-Software-Development-Meetup/events/254462660/",
+    "description": "<p>Women in Coding is hosting an Intro to HTML &amp; CSS class at The Fayetteville Library. Sign up by going to the library's registration page here: <a href=\"https://www.fflib.org/women-coding-workshop\" class=\"linkified\">https://www.fflib.org/women-coding-workshop</a></p> <p>About:<br/>Join the Syracuse Women in Coding group for an Intro to HTML and CSS: the building blocks of the web. Learn the fundamentals of using these two languages and build an online coffee shop menu with the instructor's guidance. The class is for adults and teens (11 years and up). Bring your own laptop, a limited number will be available.</p> <p>Teacher:<br/>This class will be taught by Women in Coding's cofounder, Zoe Koulouris. Zoe is a partner and software developer at Upstate Interactive. She specializes in HTML, CSS, JavaScript, Angular, NativeScript, Node.</p> <p>Sponsor:<br/>Big thank you to Hack Upstate for sponsoring our meetups. You can learn more about them at <a href=\"http://hackupstate.com/\" class=\"linkified\">http://hackupstate.com/</a>.</p> "
+  },
+  {
+    "name": "Syracuse JavaScript Meetup | Topic: JS and the DOM",
+    "local_date": "2018-10-16",
+    "local_time": "18:00",
+    "link": "https://www.meetup.com/Syracuse-Software-Development-Meetup/events/pszlhqyxnbvb/",
+    "description": "<p>Sponsored by Hack Upstate - hackupstate.com</p> <p>• What we'll do<br/>We are a group dedicated to discussing and working with the JavaScript programming language.</p> <p>Currently we meet the third Tuesday of each month, and each event has both a learning and interactive portion. Whether you’re an experienced JavaScript programmer or just getting started, we welcome and encourage all proficiency levels.</p> <p>Each month we'll be exploring the \"Current Topic\" referenced in the Meetup title. If you're not familiar with the topic, come learn something new! Already a pro? Awesome! We can use some mentors to help out with questions. Check us out for some great discussions, food, and drink!</p> <p>• What to bring<br/>Laptop</p> <p>• Important to know<br/>Harassment-free meetup, regardless of topic</p> "
+  },
+  {
+    "name": "Women in Coding - Monthly Workshop",
+    "local_date": "2018-11-10",
+    "local_time": "10:00",
+    "link": "https://www.meetup.com/Syracuse-Software-Development-Meetup/events/hjqsjqyxpbnb/",
+    "description": "<p>• What we'll do<br/>Women in Coding will be hosting workshop style classes once a month every second Saturday of the month, from 10am-12pm at The Tech Garden! Rather than having an instructor teach a specific topic, these workshops will give you the chance to work on a project or work through an online curriculum at your own pace. Never coded before? No problem. We'll help get you started. Each workshop will have at least one mentor there to provide support and answer questions.</p> <p>• What to bring<br/>Bring your computer, questions and/or a project</p> <p>• Important to know<br/>This month's mentors and their skills are TBD. Check for updates.</p> <p>Big thank you to Hack Upstate for sponsoring our meetups. You can learn more about them at <a href=\"http://hackupstate.com/\" class=\"linkified\">http://hackupstate.com/</a>.</p> "
+  },
+  {
+    "name": "OpenHack: Code together, on anything.",
+    "local_date": "2018-11-13",
+    "local_time": "18:00",
+    "link": "https://www.meetup.com/Syracuse-Software-Development-Meetup/events/gdqxgpyxpbrb/",
+    "description": "<p>• What we'll do<br/>OpenHack is a casual social coding meetup with a simple purpose: Code together, on anything.</p> <p>We welcome local developers and designers of all skill levels, interests, ages genders, you-name-it to get together to write code or push pixels. We’ll provide good food, good people, and creative energy.</p> <p>Here’s how OpenHack works:</p> <p>* You can hack on anything! Any language, framework, public/open-source, personal projects, client work… anything!<br/>* You don’t have to have an idea to hack on, you can come join someone else<br/>* We’ll kick things off with a quick round of introductions, to say who you are, what you’re working on, and if you’d like help with your idea<br/>* Food and drinks will be provided<br/>* Feel free to join us - bring a laptop, a project, and a friend!</p> <p>See more at <a href=\"http://openhacksyr.com\" class=\"linkified\">http://openhacksyr.com</a></p> <p>• What to bring<br/>A laptop if you're bringing a project, but not required</p> <p>• Important to know<br/>Please review our Code of Conduct before attending: <a href=\"http://openhacksyr.com/code_of_conduct/\" class=\"linkified\">http://openhacksyr.com/code_of_conduct/</a></p> "
+  },
+  {
+    "name": "Syracuse JavaScript Meetup | Offline Web Apps",
+    "local_date": "2018-11-20",
+    "local_time": "18:00",
+    "link": "https://www.meetup.com/Syracuse-Software-Development-Meetup/events/dqcvlqyxpbbc/",
+    "description": "<p>A huge thanks goes out to our amazing sponsor: Hack Upstate - <a href=\"http://hackupstate.com\" class=\"linkified\">http://hackupstate.com</a></p> <p>• What we'll do<br/>We are a group dedicated to discussing and working with the JavaScript programming language.</p> <p>Currently we meet the third Tuesday of each month, and each event has both a learning and interactive portion. Whether you’re an experienced JavaScript programmer or just getting started, we welcome and encourage all proficiency levels.</p> <p>Each month we'll be exploring the \"Current Topic\" referenced in the Meetup title. If you're not familiar with the topic, come learn something new! Already a pro? Awesome! We can use some mentors to help out with questions. Check us out for some great discussions, food, and drink!</p> <p>• What to bring<br/>Laptop</p> <p>• Important to know<br/>Harassment-free meetup, regardless of topic</p> "
+  },
+  {
+    "name": "Intro to JavaScript - Library Workshop by Women in Coding",
+    "local_date": "2018-12-08",
+    "local_time": "10:00",
+    "link": "https://www.meetup.com/Syracuse-Software-Development-Meetup/events/hjqsjqyxqblb/",
+    "description": "<p>This is a free introductory class on Javascript, the world's most popular programming language for a reason -- it's the primary way to build interaction on the web. Learning JavaScript is a logical next step once you've learned HTML/CSS. Our classes are open to everyone, so please share and bring a friend!<br/>***Please register at <a href=\"https://www.fflib.org/women-coding-workshop-javascript\" class=\"linkified\">https://www.fflib.org/women-coding-workshop-javascript</a></p> <p>This course is especially designed for beginners new to programming concepts, like variables, data types and functions. It will also introduce the Document Object Model (DOM) and how to use it to change html pages. Students will exit this class with a good grasp of basic programming principles and the knowledge of how to manipulate HTML elements.</p> <p>PREREQUISITES<br/>It would be best to have a working knowledge of HTML for this class. There are many online resources to learn HTML, including this free course from Code Academy: <a href=\"https://www.codecademy.com/learn/web\" class=\"linkified\">https://www.codecademy.com/learn/web</a></p> <p>Big thank you to Hack Upstate for sponsoring our meetups. You can learn more about them at <a href=\"http://hackupstate.com/\" class=\"linkified\">http://hackupstate.com/</a>.</p> "
+  },
+  {
+    "name": "OpenHack: Code together, on anything.",
+    "local_date": "2018-12-11",
+    "local_time": "18:00",
+    "link": "https://www.meetup.com/Syracuse-Software-Development-Meetup/events/gdqxgpyxqbpb/",
+    "description": "<p>• What we'll do<br/>OpenHack is a casual social coding meetup with a simple purpose: Code together, on anything.</p> <p>We welcome local developers and designers of all skill levels, interests, ages genders, you-name-it to get together to write code or push pixels. We’ll provide good food, good people, and creative energy.</p> <p>Here’s how OpenHack works:</p> <p>* You can hack on anything! Any language, framework, public/open-source, personal projects, client work… anything!<br/>* You don’t have to have an idea to hack on, you can come join someone else<br/>* We’ll kick things off with a quick round of introductions, to say who you are, what you’re working on, and if you’d like help with your idea<br/>* Food and drinks will be provided<br/>* Feel free to join us - bring a laptop, a project, and a friend!</p> <p>See more at <a href=\"http://openhacksyr.com\" class=\"linkified\">http://openhacksyr.com</a></p> <p>• What to bring<br/>A laptop if you're bringing a project, but not required</p> <p>• Important to know<br/>Please review our Code of Conduct before attending: <a href=\"http://openhacksyr.com/code_of_conduct/\" class=\"linkified\">http://openhacksyr.com/code_of_conduct/</a></p> "
+  },
+  {
+    "name": "Syracuse JavaScript Meetup | Topic: Creating visuals with JavaScript (p5.js)",
+    "local_date": "2018-12-18",
+    "local_time": "18:00",
+    "link": "https://www.meetup.com/Syracuse-Software-Development-Meetup/events/dqcvlqyxqbxb/",
+    "description": "<p>A huge thanks goes out to our amazing sponsor: Hack Upstate - <a href=\"http://hackupstate.com\" class=\"linkified\">http://hackupstate.com</a></p> <p>• What we'll do<br/>We are a group dedicated to discussing and working with the JavaScript programming language.</p> <p>Currently we meet the third Tuesday of each month, and each event has both a learning and interactive portion. Whether you’re an experienced JavaScript programmer or just getting started, we welcome and encourage all proficiency levels.</p> <p>Each month we'll be exploring the \"Current Topic\" referenced in the Meetup title. If you're not familiar with the topic, come learn something new! Already a pro? Awesome! We can use some mentors to help out with questions. Check us out for some great discussions, food, and drink!</p> <p>• What to bring<br/>Laptop</p> <p>• Important to know<br/>Harassment-free meetup, regardless of topic</p> "
+  },
+  {
+    "name": "OpenHack: Code together, on anything.",
+    "local_date": "2019-01-08",
+    "local_time": "18:00",
+    "link": "https://www.meetup.com/Syracuse-Software-Development-Meetup/events/gdqxgpyzcblb/",
+    "description": "<p>• What we'll do<br/>OpenHack is a casual social coding meetup with a simple purpose: Code together, on anything.</p> <p>We welcome local developers and designers of all skill levels, interests, ages genders, you-name-it to get together to write code or push pixels. We’ll provide good food, good people, and creative energy.</p> <p>Here’s how OpenHack works:</p> <p>* You can hack on anything! Any language, framework, public/open-source, personal projects, client work… anything!<br/>* You don’t have to have an idea to hack on, you can come join someone else<br/>* We’ll kick things off with a quick round of introductions, to say who you are, what you’re working on, and if you’d like help with your idea<br/>* Food and drinks will be provided<br/>* Feel free to join us - bring a laptop, a project, and a friend!</p> <p>See more at <a href=\"http://openhacksyr.com\" class=\"linkified\">http://openhacksyr.com</a></p> <p>• What to bring<br/>A laptop if you're bringing a project, but not required</p> <p>• Important to know<br/>Please review our Code of Conduct before attending: <a href=\"http://openhacksyr.com/code_of_conduct/\" class=\"linkified\">http://openhacksyr.com/code_of_conduct/</a></p> "
+  },
+  {
+    "name": "Women in Coding - Monthly Workshop",
+    "local_date": "2019-01-12",
+    "local_time": "10:00",
+    "link": "https://www.meetup.com/Syracuse-Software-Development-Meetup/events/hjqsjqyzcbqb/",
+    "description": "<p>• What we'll do<br/>Women in Coding will be hosting workshop style classes once a month every second Saturday of the month, from 10am-12pm at The Tech Garden! Rather than having an instructor teach a specific topic, these workshops will give you the chance to work on a project or work through an online curriculum at your own pace. Never coded before? No problem. We'll help get you started. Each workshop will have at least one mentor there to provide support and answer questions.</p> <p>• What to bring<br/>Bring your computer, questions and/or a project</p> <p>• Important to know<br/>This month's mentors: Christy Presler, Annalena Davis, and Mike Vormwald<br/>Skills: Web development, programming fundamentals, testing, console/terminal, deployment strategies, static sites, databases<br/>Languages: Ruby on Rails, Java, Bash, Elixir, SQL, HTML, CSS, Javascript, PHP, jQuery, Wordpress</p> <p>Big thank you to Hack Upstate for sponsoring our meetups. You can learn more about them at <a href=\"http://hackupstate.com/\" class=\"linkified\">http://hackupstate.com/</a>.</p> "
+  },
+  {
+    "name": "Syracuse JavaScript Meetup | Topic: GatsbyJS (or Houdini)",
+    "local_date": "2019-01-15",
+    "local_time": "18:00",
+    "link": "https://www.meetup.com/Syracuse-Software-Development-Meetup/events/dqcvlqyzcbtb/",
+    "description": "<p>A huge thanks goes out to our amazing sponsor: Hack Upstate - <a href=\"http://hackupstate.com\" class=\"linkified\">http://hackupstate.com</a></p> <p>• What we'll do<br/>We are a group dedicated to discussing and working with the JavaScript programming language.</p> <p>Currently we meet the third Tuesday of each month, and each event has both a learning and interactive portion. Whether you’re an experienced JavaScript programmer or just getting started, we welcome and encourage all proficiency levels.</p> <p>Each month we'll be exploring the \"Current Topic\" referenced in the Meetup title. If you're not familiar with the topic, come learn something new! Already a pro? Awesome! We can use some mentors to help out with questions. Check us out for some great discussions, food, and drink!</p> <p>• What to bring<br/>Laptop</p> <p>• Important to know<br/>Harassment-free meetup, regardless of topic</p> "
+  },
+  {
+    "name": "Women in Coding - Intro to Mobile Development with JavaScript",
+    "local_date": "2019-02-09",
+    "local_time": "10:00",
+    "link": "https://www.meetup.com/Syracuse-Software-Development-Meetup/events/hjqsjqyzdbmb/",
+    "description": "<p>This is a free, introductory class on developing cross-platform mobile apps with JavaScript (the language of the web). With increasingly mobile users, it has never been more important to design applications for all devices. It has also never been easier for web developers to create native mobile applications using web technologies.</p> <p>Zoe will start with a brief overview/history of cross-platform mobile development. Then, Zoe will give an overview of NativeScript, her framework of choice for native mobile development. Finally, we'll close by building our very own app! More info at: <a href=\"https://www.fflib.org/women-coding-workshop-javascript-part-2\" class=\"linkified\">https://www.fflib.org/women-coding-workshop-javascript-part-2</a></p> <p>• What to bring<br/>Bring your computer. All are welcome, but it's preferred to have working knowledge of web technologies (HTML, CSS, JavaScript).</p> <p>Big thank you to Hack Upstate for sponsoring our meetups. You can learn more about them at <a href=\"http://hackupstate.com/\" class=\"linkified\">http://hackupstate.com/</a>.</p> "
+  },
+  {
+    "name": "Syracuse JavaScript Meetup | Topic: NodeJS Servers",
+    "local_date": "2019-02-19",
+    "local_time": "18:00",
+    "link": "https://www.meetup.com/Syracuse-Software-Development-Meetup/events/dqcvlqyzdbzb/",
+    "description": "<p>A huge thanks goes out to our amazing sponsor: Hack Upstate - <a href=\"http://hackupstate.com\" class=\"linkified\">http://hackupstate.com</a></p> <p>• What we'll do<br/>We are a group dedicated to discussing and working with the JavaScript programming language.</p> <p>Currently we meet the third Tuesday of each month, and each event has both a learning and interactive portion. Whether you’re an experienced JavaScript programmer or just getting started, we welcome and encourage all proficiency levels.</p> <p>Each month we'll be exploring the \"Current Topic\" referenced in the Meetup title. If you're not familiar with the topic, come learn something new! Already a pro? Awesome! We can use some mentors to help out with questions. Check us out for some great discussions, food, and drink!</p> <p>• What to bring<br/>Laptop</p> <p>• Important to know<br/>Harassment-free meetup, regardless of topic</p> "
+  },
+  {
+    "name": "Coffee & Code",
+    "local_date": "2019-02-24",
+    "local_time": "16:00",
+    "link": "https://www.meetup.com/Syracuse-Software-Development-Meetup/events/259189194/",
+    "description": "<p>Stop by for some Sunday afternoon coffee and coding!</p> <p>This is a general topic/networking event, nothing language-specific. Just bring yourself, something to code on, and enjoy some coffee with (new) friends!</p> <p>There's only room for about 10 or so people in the Community Room at this location, but there's more seating in the general cafe area as well. The Community Room has a large screen with a HDMI hookup and an array of outlets for plugging in, so it can be used for presenting/teaching/etc.</p> "
+  },
+  {
+    "name": "Intro to Python and Arduino Lab by Women in Coding",
+    "local_date": "2019-03-09",
+    "local_time": "10:00",
+    "link": "https://www.meetup.com/Syracuse-Software-Development-Meetup/events/hjqsjqyzfbmb/",
+    "description": "<p>This month's Women in Coding event will be a two-part class at DeWitt Library. Please register for each part you plan to attend on the Library's website:<br/>Intro to Python:<br/><a href=\"http://onlibdewitt.evanced.info/signup/EventDetails?EventId=2679&amp;backTo=Calendar&amp;startDate=2019/03/01\" class=\"linkified\">http://onlibdewitt.evanced.info/signup/EventDetails?EventId=2679&amp;backTo=Calendar&amp;startDate=2019/03/01</a><br/>Arduino Lab:<br/><a href=\"http://onlibdewitt.evanced.info/signup/EventDetails?EventId=2680&amp;backTo=Calendar&amp;startDate=2019/03/01\" class=\"linkified\">http://onlibdewitt.evanced.info/signup/EventDetails?EventId=2680&amp;backTo=Calendar&amp;startDate=2019/03/01</a></p> <p>Intro to Python 10 - 11:30am<br/>Taught by Alison McCauley<br/>Python is used for controlling and increasing the functionality of software, websites, databases, and can perform complex math with large data sets, among many other useful activities. With this readable, flexible programming language you can get the most out of your computer, for home or work applications.</p> <p>Arduino Lab 12 - 1:30pm<br/>Taught by Josh Wright<br/>Arduino is an easy-to-use electronics controller that works with inputs and outputs to perform tasks assigned by the user. The Arduino software is great for beginners and flexible enough for advanced users.<br/>In this exciting, hands-on workshop participants will use the Library’s Arduino kits to learn more about how Arduino works and the possibilities of what Arduino can do.</p> <p>• What to bring<br/>Bring your computer. Arduino's will be provided.</p> <p>Big thank you to Hack Upstate for sponsoring our meetups. You can learn more about them at <a href=\"http://hackupstate.com/\" class=\"linkified\">http://hackupstate.com/</a>.</p> "
+  },
+  {
+    "name": "OpenHack: Code together, on anything.",
+    "local_date": "2019-03-12",
+    "local_time": "18:00",
+    "link": "https://www.meetup.com/Syracuse-Software-Development-Meetup/events/gdqxgpyzfbqb/",
+    "description": "<p>• What we'll do<br/>OpenHack is a casual social coding meetup with a simple purpose: Code together, on anything.</p> <p>We welcome local developers and designers of all skill levels, interests, ages genders, you-name-it to get together to write code or push pixels. We’ll provide good food, good people, and creative energy.</p> <p>Here’s how OpenHack works:</p> <p>* You can hack on anything! Any language, framework, public/open-source, personal projects, client work… anything!<br/>* You don’t have to have an idea to hack on, you can come join someone else<br/>* We’ll kick things off with a quick round of introductions, to say who you are, what you’re working on, and if you’d like help with your idea<br/>* Food and drinks will be provided<br/>* Feel free to join us - bring a laptop, a project, and a friend!</p> <p>See more at <a href=\"http://openhacksyr.com\" class=\"linkified\">http://openhacksyr.com</a></p> <p>• What to bring<br/>A laptop if you're bringing a project, but not required</p> <p>• Important to know<br/>Please review our Code of Conduct before attending: <a href=\"http://openhacksyr.com/code_of_conduct/\" class=\"linkified\">http://openhacksyr.com/code_of_conduct/</a></p> "
+  },
+  {
+    "name": "Syracuse JavaScript Meetup | Topic: React",
+    "local_date": "2019-03-19",
+    "local_time": "18:00",
+    "link": "https://www.meetup.com/Syracuse-Software-Development-Meetup/events/dqcvlqyzfbzb/",
+    "description": "<p>A huge thanks goes out to our amazing sponsor: Hack Upstate - <a href=\"http://hackupstate.com\" class=\"linkified\">http://hackupstate.com</a></p> <p>• What we'll do<br/>We are a group dedicated to discussing and working with the JavaScript programming language.</p> <p>Currently we meet the third Tuesday of each month, and each event has both a learning and interactive portion. Whether you’re an experienced JavaScript programmer or just getting started, we welcome and encourage all proficiency levels.</p> <p>Each month we'll be exploring the \"Current Topic\" referenced in the Meetup title. If you're not familiar with the topic, come learn something new! Already a pro? Awesome! We can use some mentors to help out with questions. Check us out for some great discussions, food, and drink!</p> <p>• What to bring<br/>Laptop</p> <p>• Important to know<br/>Harassment-free meetup, regardless of topic</p> "
+  },
+  {
+    "name": "OpenHack: Code together, on anything.",
+    "local_date": "2019-04-09",
+    "local_time": "18:00",
+    "link": "https://www.meetup.com/Syracuse-Software-Development-Meetup/events/gdqxgpyzgbmb/",
+    "description": "<p>• What we'll do<br/>OpenHack is a casual social coding meetup with a simple purpose: Code together, on anything.</p> <p>We welcome local developers and designers of all skill levels, interests, ages genders, you-name-it to get together to write code or push pixels. We’ll provide good food, good people, and creative energy.</p> <p>Here’s how OpenHack works:</p> <p>* You can hack on anything! Any language, framework, public/open-source, personal projects, client work… anything!<br/>* You don’t have to have an idea to hack on, you can come join someone else<br/>* We’ll kick things off with a quick round of introductions, to say who you are, what you’re working on, and if you’d like help with your idea<br/>* Food and drinks will be provided<br/>* Feel free to join us - bring a laptop, a project, and a friend!</p> <p>See more at <a href=\"http://openhacksyr.com\" class=\"linkified\">http://openhacksyr.com</a></p> <p>• What to bring<br/>A laptop if you're bringing a project, but not required</p> <p>• Important to know<br/>Please review our Code of Conduct before attending: <a href=\"http://openhacksyr.com/code_of_conduct/\" class=\"linkified\">http://openhacksyr.com/code_of_conduct/</a></p> "
+  },
+  {
+    "name": "Syracuse JavaScript Meetup | Topic: End to End Testing w/ Cypress",
+    "local_date": "2019-04-16",
+    "local_time": "18:00",
+    "link": "https://www.meetup.com/Syracuse-Software-Development-Meetup/events/dqcvlqyzgbvb/",
+    "description": "<p>A huge thanks goes out to our amazing sponsor: Hack Upstate - <a href=\"http://hackupstate.com\" class=\"linkified\">http://hackupstate.com</a></p> <p>• What we'll do<br/>We are a group dedicated to discussing and working with the JavaScript programming language.</p> <p>Currently we meet the third Tuesday of each month, and each event has both a learning and interactive portion. Whether you’re an experienced JavaScript programmer or just getting started, we welcome and encourage all proficiency levels.</p> <p>Each month we'll be exploring the \"Current Topic\" referenced in the Meetup title. If you're not familiar with the topic, come learn something new! Already a pro? Awesome! We can use some mentors to help out with questions. Check us out for some great discussions, food, and drink!</p> <p>• What to bring<br/>Laptop</p> <p>• Important to know<br/>Harassment-free meetup, regardless of topic</p> "
+  },
+  {
+    "name": "Women in Coding - Monthly Workshop",
+    "local_date": "2019-05-11",
+    "local_time": "10:00",
+    "link": "https://www.meetup.com/Syracuse-Software-Development-Meetup/events/hjqsjqyzhbpb/",
+    "description": "<p>• What we'll do<br/>Women in Coding will be hosting workshop style classes once a month every second Saturday of the month, from 10am-12pm at The Tech Garden! Rather than having an instructor teach a specific topic, these workshops will give you the chance to work on a project or work through an online curriculum at your own pace. Never coded before? No problem. We'll help get you started. Each workshop will have at least one mentor there to provide support and answer questions.</p> <p>• What to bring<br/>Bring your computer, questions and/or a project</p> <p>​• Mentors: Alex Jansing and Annalena Davis<br/>• Skills: Web development, programming fundamentals, testing, console/terminal, deployment strategies, static sites, databases<br/>• Languages: Java, Python, HTML, CSS, Javascript, PHP</p> <p>Big thank you to Hack Upstate for sponsoring our meetups. You can learn more about them at <a href=\"http://hackupstate.com/\" class=\"linkified\">http://hackupstate.com/</a>.</p> "
+  },
+  {
+    "name": "OpenHack: Code together, on anything.",
+    "local_date": "2019-05-14",
+    "local_time": "18:00",
+    "link": "https://www.meetup.com/Syracuse-Software-Development-Meetup/events/gdqxgpyzhbsb/",
+    "description": "<p>• What we'll do<br/>OpenHack is a casual social coding meetup with a simple purpose: Code together, on anything.</p> <p>We welcome local developers and designers of all skill levels, interests, ages genders, you-name-it to get together to write code or push pixels. We’ll provide good food, good people, and creative energy.</p> <p>Here’s how OpenHack works:</p> <p>* You can hack on anything! Any language, framework, public/open-source, personal projects, client work… anything!<br/>* You don’t have to have an idea to hack on, you can come join someone else<br/>* We’ll kick things off with a quick round of introductions, to say who you are, what you’re working on, and if you’d like help with your idea<br/>* Food and drinks will be provided<br/>* Feel free to join us - bring a laptop, a project, and a friend!</p> <p>See more at <a href=\"http://openhacksyr.com\" class=\"linkified\">http://openhacksyr.com</a></p> <p>• What to bring<br/>A laptop if you're bringing a project, but not required</p> <p>• Important to know<br/>Please review our Code of Conduct before attending: <a href=\"http://openhacksyr.com/code_of_conduct/\" class=\"linkified\">http://openhacksyr.com/code_of_conduct/</a></p> "
+  },
+  {
+    "name": "Syracuse JavaScript Meetup | Topic: Open JS Forum",
+    "local_date": "2019-05-21",
+    "local_time": "18:00",
+    "link": "https://www.meetup.com/Syracuse-Software-Development-Meetup/events/dqcvlqyzhbcc/",
+    "description": "<p>A huge thanks goes out to our amazing sponsor: Hack Upstate - <a href=\"http://hackupstate.com\" class=\"linkified\">http://hackupstate.com</a></p> <p>• What we'll do<br/>We are a group dedicated to discussing and working with the JavaScript programming language.</p> <p>Currently we meet the third Tuesday of each month, and each event has both a learning and interactive portion. Whether you’re an experienced JavaScript programmer or just getting started, we welcome and encourage all proficiency levels.</p> <p>Each month we'll be exploring the \"Current Topic\" referenced in the Meetup title. If you're not familiar with the topic, come learn something new! Already a pro? Awesome! We can use some mentors to help out with questions. Check us out for some great discussions, food, and drink!</p> <p>• What to bring<br/>Laptop</p> <p>• Important to know<br/>Harassment-free meetup, regardless of topic</p> "
+  },
+  {
+    "name": "Women in Coding - Monthly Workshop",
+    "local_date": "2019-06-08",
+    "local_time": "10:00",
+    "link": "https://www.meetup.com/Syracuse-Software-Development-Meetup/events/rbmxbryzjblb/",
+    "description": "<p>• What we'll do<br/>Women in Coding will be hosting workshop style classes once a month every second Saturday of the month, from 10am-12pm at The Tech Garden! Rather than having an instructor teach a specific topic, these workshops will give you the chance to work on a project or work through an online curriculum at your own pace. Never coded before? No problem. We'll help get you started. Each workshop will have at least one mentor there to provide support and answer questions.</p> <p>• What to bring<br/>Bring your computer, questions and/or a project</p> <p>• ​Mentors: Ryan Gaus and Annalena Davis<br/>Skills: Web development, programming fundamentals, testing, console/terminal, deployment strategies, static sites, databases, front end and server side<br/>Languages: JavaScript, Python, Elixir, HTML, CSS, PHP</p> <p>Big thank you to Hack Upstate for sponsoring our meetups. You can learn more about them at <a href=\"http://hackupstate.com/\" class=\"linkified\">http://hackupstate.com/</a>.</p> "
+  },
+  {
+    "name": "OpenHack: Code together, on anything.",
+    "local_date": "2019-06-11",
+    "local_time": "18:00",
+    "link": "https://www.meetup.com/Syracuse-Software-Development-Meetup/events/gdqxgpyzjbpb/",
+    "description": "<p>• What we'll do<br/>OpenHack is a casual social coding meetup with a simple purpose: Code together, on anything.</p> <p>We welcome local developers and designers of all skill levels, interests, ages genders, you-name-it to get together to write code or push pixels. We’ll provide good food, good people, and creative energy.</p> <p>Here’s how OpenHack works:</p> <p>* You can hack on anything! Any language, framework, public/open-source, personal projects, client work… anything!<br/>* You don’t have to have an idea to hack on, you can come join someone else<br/>* We’ll kick things off with a quick round of introductions, to say who you are, what you’re working on, and if you’d like help with your idea<br/>* Food and drinks will be provided<br/>* Feel free to join us - bring a laptop, a project, and a friend!</p> <p>See more at <a href=\"http://openhacksyr.com\" class=\"linkified\">http://openhacksyr.com</a></p> <p>• What to bring<br/>A laptop if you're bringing a project, but not required</p> <p>• Important to know<br/>Please review our Code of Conduct before attending: <a href=\"http://openhacksyr.com/code_of_conduct/\" class=\"linkified\">http://openhacksyr.com/code_of_conduct/</a></p> "
+  },
+  {
+    "name": "Syracuse JavaScript Meetup | Topic: Making a RESTful API with Sails.js",
+    "local_date": "2019-06-18",
+    "local_time": "18:00",
+    "link": "https://www.meetup.com/Syracuse-Software-Development-Meetup/events/dqcvlqyzjbxb/",
+    "description": "<p>A huge thanks goes out to our amazing sponsor: Hack Upstate - <a href=\"http://hackupstate.com\" class=\"linkified\">http://hackupstate.com</a></p> <p>• What we'll do<br/>We are a group dedicated to discussing and working with the JavaScript programming language.</p> <p>Currently we meet the third Tuesday of each month, and each event has both a learning and interactive portion. Whether you’re an experienced JavaScript programmer or just getting started, we welcome and encourage all proficiency levels.</p> <p>Each month we'll be exploring the \"Current Topic\" referenced in the Meetup title. If you're not familiar with the topic, come learn something new! Already a pro? Awesome! We can use some mentors to help out with questions. Check us out for some great discussions, food, and drink!</p> <p>• What to bring<br/>Laptop</p> <p>• Important to know<br/>Harassment-free meetup, regardless of topic</p> "
+  },
+  {
+    "name": "OpenHack: Code together, on anything.",
+    "local_date": "2019-07-09",
+    "local_time": "18:00",
+    "link": "https://www.meetup.com/Syracuse-Software-Development-Meetup/events/gdqxgpyzkbmb/",
+    "description": "<p>• What we'll do<br/>OpenHack is a casual social coding meetup with a simple purpose: Code together, on anything.</p> <p>We welcome local developers and designers of all skill levels, interests, ages genders, you-name-it to get together to write code or push pixels. We’ll provide good food, good people, and creative energy.</p> <p>Here’s how OpenHack works:</p> <p>* You can hack on anything! Any language, framework, public/open-source, personal projects, client work… anything!<br/>* You don’t have to have an idea to hack on, you can come join someone else<br/>* We’ll kick things off with a quick round of introductions, to say who you are, what you’re working on, and if you’d like help with your idea<br/>* Food and drinks will be provided<br/>* Feel free to join us - bring a laptop, a project, and a friend!</p> <p>See more at <a href=\"http://openhacksyr.com\" class=\"linkified\">http://openhacksyr.com</a></p> <p>• What to bring<br/>A laptop if you're bringing a project, but not required</p> <p>• Important to know<br/>Please review our Code of Conduct before attending: <a href=\"http://openhacksyr.com/code_of_conduct/\" class=\"linkified\">http://openhacksyr.com/code_of_conduct/</a></p> "
+  },
+  {
+    "name": "Women in Coding - Accessible Web Development Class",
+    "local_date": "2019-07-13",
+    "local_time": "10:00",
+    "link": "https://www.meetup.com/Syracuse-Software-Development-Meetup/events/rbmxbryzkbrb/",
+    "description": "<p>This month Annalena Davis will be teaching a class on Developing Accessible Websites. Learn about building sites that are accessible to a larger variety of users. Topics will include:<br/>• Different ways people navigate websites<br/>• Tools to improve accessibility (skip links, Semantic HTML, color contrast, keyboard focus, etc)<br/>• What to consider when adding JavaScript functionality<br/>• How to test your site for accessibility</p> <p>• What to bring<br/>Bring your computer.</p> <p>• Helpful to know<br/>It will help to have some knowledge of HTML and CSS.</p> <p>Big thank you to Hack Upstate for sponsoring our meetups. You can learn more about them at <a href=\"http://hackupstate.com/\" class=\"linkified\">http://hackupstate.com/</a>.</p> "
+  },
+  {
+    "name": "Syracuse JavaScript Meetup | Topic: Open Source Development Talk & Q&A",
+    "local_date": "2019-07-16",
+    "local_time": "18:00",
+    "link": "https://www.meetup.com/Syracuse-Software-Development-Meetup/events/dqcvlqyzkbvb/",
+    "description": "<p>A huge thanks goes out to our amazing sponsor: Hack Upstate - <a href=\"http://hackupstate.com\" class=\"linkified\">http://hackupstate.com</a></p> <p>• What we'll do<br/>We are a group dedicated to discussing and working with the JavaScript programming language.</p> <p>Currently we meet the third Tuesday of each month, and each event has both a learning and interactive portion. Whether you’re an experienced JavaScript programmer or just getting started, we welcome and encourage all proficiency levels.</p> <p>Each month we'll be exploring the \"Current Topic\" referenced in the Meetup title. If you're not familiar with the topic, come learn something new! Already a pro? Awesome! We can use some mentors to help out with questions. Check us out for some great discussions, food, and drink!</p> <p>• What to bring<br/>Laptop</p> <p>• Important to know<br/>Harassment-free meetup, regardless of topic</p> "
+  },
+  {
+    "name": "Code for Syracuse Kick-Off",
+    "local_date": "2019-07-30",
+    "local_time": "18:00",
+    "link": "https://www.meetup.com/Syracuse-Software-Development-Meetup/events/262762003/",
+    "description": "<p>Join us for our Code for Syracuse kickoff event. Code for Syracuse is a group of technologists with a simple purpose, work together on things that matter. We are partnering with local non-profits and local government build a better Syracuse for everyone. That means we need everyone: community leaders and coders, subject-matter experts and project managers, activists and designers, public servants and curious residents.</p> <p>What we will do:<br/>Enjoy some food and drinks as we learn more Learn about Code for Syracuse and how we are part of the national Code for America movement.</p> <p>*You don’t have to bring a laptop to the kickoff event.</p> <p>First Meeting Agenda:<br/>- Event starts at 6:00 PM<br/>- Food and informal introductions<br/>- Presentation on what Code for America is<br/>- Talk from Sam Edelstein, City of Syracuse Innovation Team Chief Data Officer, to discuss potential collaborative projects<br/>- Wrap up at 7:30 PM</p> <p>Much thanks to our amazing sponsor Hack Upstate. Check out what they are up to at <a href=\"https://hackupstate.com\" class=\"linkified\">https://hackupstate.com</a> Also, special thanks to Syracuse CoWorks for letting us use their awesome space. Check them out at <a href=\"http://www.syracusecoworks.com\" class=\"linkified\">http://www.syracusecoworks.com</a>.</p> "
+  },
+  {
+    "name": "Bubble Tea and Code",
+    "local_date": "2019-08-11",
+    "local_time": "15:00",
+    "link": "https://www.meetup.com/Syracuse-Software-Development-Meetup/events/263422109/",
+    "description": "<p>A get-together sit down, grab a drink of bubble tea, and code. It's a time to ask questions to each other, talk projects, help each other be awesome coders, or just to code with new friends. All levels are welcome!! Feel free to come and work, help, or just have a chat.</p> "
+  },
+  {
+    "name": "OpenHack: Code together, on anything.",
+    "local_date": "2019-08-13",
+    "local_time": "18:00",
+    "link": "https://www.meetup.com/Syracuse-Software-Development-Meetup/events/gdqxgpyzlbrb/",
+    "description": "<p>• What we'll do<br/>OpenHack is a casual social coding meetup with a simple purpose: Code together, on anything.</p> <p>We welcome local developers and designers of all skill levels, interests, ages genders, you-name-it to get together to write code or push pixels. We’ll provide good food, good people, and creative energy.</p> <p>Here’s how OpenHack works:</p> <p>* You can hack on anything! Any language, framework, public/open-source, personal projects, client work… anything!<br/>* You don’t have to have an idea to hack on, you can come join someone else<br/>* We’ll kick things off with a quick round of introductions, to say who you are, what you’re working on, and if you’d like help with your idea<br/>* Food and drinks will be provided<br/>* Feel free to join us - bring a laptop, a project, and a friend!</p> <p>See more at <a href=\"http://openhacksyr.com\" class=\"linkified\">http://openhacksyr.com</a></p> <p>• What to bring<br/>A laptop if you're bringing a project, but not required</p> <p>• Important to know<br/>Please review our Code of Conduct before attending: <a href=\"http://openhacksyr.com/code_of_conduct/\" class=\"linkified\">http://openhacksyr.com/code_of_conduct/</a></p> "
+  },
+  {
+    "name": "Women in Coding - Arduino Lab",
+    "local_date": "2019-08-17",
+    "local_time": "10:00",
+    "link": "https://www.meetup.com/Syracuse-Software-Development-Meetup/events/rbmxbryzlbnb/",
+    "description": "<p>Please register with the Library after July 1st <a href=\"https://www.fflib.org/arduino-lab\" class=\"linkified\">https://www.fflib.org/arduino-lab</a></p> <p>Josh Wright is back with another Arduino Lab! Arduino is an easy-to-use electronics controller that works with inputs and outputs to perform tasks assigned by the user. The Arduino software is great for beginners and flexible enough for advanced users. In this hands-on workshop participants will use the Library's Arduino kits to learn more about how Arduino works and the possibilities of what Arduino can do.</p> <p>• What to bring<br/>Bring your computer, with Arduino installed. If you have an Arduino kit, feel free to bring it. If not, the Library has a number available for participants to use and share.</p> <p>Big thank you to Hack Upstate for sponsoring our meetups. You can learn more about them at <a href=\"http://hackupstate.com/\" class=\"linkified\">http://hackupstate.com/</a>.</p> "
+  },
+  {
+    "name": "Syracuse JavaScript Meetup | Topic: Open JS Forum",
+    "local_date": "2019-08-20",
+    "local_time": "18:00",
+    "link": "https://www.meetup.com/Syracuse-Software-Development-Meetup/events/dqcvlqyzlbbc/",
+    "description": "<p>A huge thanks goes out to our amazing sponsor: Hack Upstate - <a href=\"http://hackupstate.com\" class=\"linkified\">http://hackupstate.com</a></p> <p>• What we'll do<br/>We are a group dedicated to discussing and working with the JavaScript programming language.</p> <p>Currently we meet the third Tuesday of each month, and each event has both a learning and interactive portion. Whether you’re an experienced JavaScript programmer or just getting started, we welcome and encourage all proficiency levels.</p> <p>This month, we'll be coming together to share any individual Javascript projects that we're working on or frameworks that we're learning. Several developers will be available to mentor those who are working through online Javascript tutorials.</p> <p>There will be pizza!</p> <p>• What to bring<br/>Laptop</p> <p>• Important to know<br/>Harassment-free meetup, regardless of topic</p> "
+  },
+  {
+    "name": "Code for Syracuse Project Follow-up Discussion",
+    "local_date": "2019-08-27",
+    "local_time": "18:00",
+    "link": "https://www.meetup.com/Syracuse-Software-Development-Meetup/events/263857254/",
+    "description": "<p>Details<br/>Join us for a follow-up meeting to listen to non-profit partners pitch project ideas and discuss and finalize projects related to housing and schools to work on.</p> <p>Code for Syracuse is a group of technologists with a simple purpose, work together on things that matter. We are partnering with local non-profits and local government build a better Syracuse for everyone. That means we need everyone: community leaders and coders, subject-matter experts and project managers, activists and designers, public servants and curious residents.</p> <p>*You are welcome to bring your laptop but you don’t have to to the follow-up discussion.*</p> <p>First Meeting Agenda:<br/>- Event starts at 6:00 PM<br/>- Food and informal introductions<br/>- Presentation from non-profit partners on project ideas (TBD)<br/>- Discussion on project ideas, finalize on two projects to work on in the upcoming months<br/>- Wrap up at 7:30 PM</p> <p>Much thanks to our amazing sponsor Hack Upstate. Check out what they are up to at <a href=\"https://hackupstate.com\" class=\"linkified\">https://hackupstate.com</a> Also, special thanks to Syracuse CoWorks for letting us use their awesome space. Check them out at <a href=\"http://www.syracusecoworks.com\" class=\"linkified\">http://www.syracusecoworks.com</a>.</p> "
+  },
+  {
+    "name": "OpenHack: Code together, on anything.",
+    "local_date": "2019-09-10",
+    "local_time": "18:00",
+    "link": "https://www.meetup.com/Syracuse-Software-Development-Meetup/events/gdqxgpyzmbnb/",
+    "description": "<p>• What we'll do<br/>OpenHack is a casual social coding meetup with a simple purpose: Code together, on anything.</p> <p>We welcome local developers and designers of all skill levels, interests, ages genders, you-name-it to get together to write code or push pixels. We’ll provide good food, good people, and creative energy.</p> <p>Here’s how OpenHack works:</p> <p>* You can hack on anything! Any language, framework, public/open-source, personal projects, client work… anything!<br/>* You don’t have to have an idea to hack on, you can come join someone else<br/>* We’ll kick things off with a quick round of introductions, to say who you are, what you’re working on, and if you’d like help with your idea<br/>* Food and drinks will be provided<br/>* Feel free to join us - bring a laptop, a project, and a friend!</p> <p>See more at <a href=\"http://openhacksyr.com\" class=\"linkified\">http://openhacksyr.com</a></p> <p>• What to bring<br/>A laptop if you're bringing a project, but not required</p> <p>• Important to know<br/>Please review our Code of Conduct before attending: <a href=\"http://openhacksyr.com/code_of_conduct/\" class=\"linkified\">http://openhacksyr.com/code_of_conduct/</a></p> "
+  },
+  {
+    "name": "Women in Coding - Monthly Workshop",
+    "local_date": "2019-09-14",
+    "local_time": "10:00",
+    "link": "https://www.meetup.com/Syracuse-Software-Development-Meetup/events/rbmxbryzmbsb/",
+    "description": "<p>• What we'll do<br/>Women in Coding will be hosting workshop style classes once a month every second Saturday of the month, from 10am-12pm at The Tech Garden! Rather than having an instructor teach a specific topic, these workshops will give you the chance to work on a project or work through an online curriculum at your own pace. Never coded before? No problem. We'll help get you started. Each workshop will have at least one mentor there to provide support and answer questions.</p> <p>• What to bring<br/>Bring your computer, questions and/or a project</p> <p>• This month's Mentors: Max Matthews, Christy Presler, Zoe Koulouris<br/>Skills/Languages: JavaScript, Node, Express, React, SQL, HTML/CSS, Angular, Nativescript, jQuery, Wordpress</p> <p>Big thank you to Hack Upstate for sponsoring our meetups. You can learn more about them at <a href=\"http://hackupstate.com/\" class=\"linkified\">http://hackupstate.com/</a>.</p> "
+  },
+  {
+    "name": "Syracuse JavaScript Meetup | Topic: TBD",
+    "local_date": "2019-09-17",
+    "local_time": "18:00",
+    "link": "https://www.meetup.com/Syracuse-Software-Development-Meetup/events/jccphryzmbwb/",
+    "description": "<p>We are a group dedicated to discussing and working with the JavaScript programming language.</p> <p>Currently we meet the third Tuesday of each month, and each event has both a learning and interactive portion. Whether you’re an experienced JavaScript programmer or just getting started, we welcome and encourage all proficiency levels.</p> <p>Each month we'll be exploring the \"Current Topic\" referenced in the Meetup title. If you're not familiar with the topic, come learn something new! Already a pro? Awesome! We can use some mentors to help out with questions. Check us out for some great discussions, food, and drink!</p> <p>• What to bring<br/>Laptop</p> <p>• Important to know<br/>Harassment-free meetup, regardless of topic</p> "
+  },
+  {
+    "name": "Code for Syracuse Monthly Hack Night",
+    "local_date": "2019-09-24",
+    "local_time": "18:00",
+    "link": "https://www.meetup.com/Syracuse-Software-Development-Meetup/events/264520180/",
+    "description": "<p>Join us for our monthly night of Civic Hacking where we are currently working together on web-based projects related to housing issues in the Syracuse area.</p> <p>Code for Syracuse is a group of technologists with a simple purpose, work together on things that matter. We are partnering with local non-profits and local government build a better Syracuse for everyone. That means we need everyone: community leaders and coders, subject-matter experts and project managers, activists and designers, public servants and curious residents.</p> <p>*You are welcome to bring your laptop, but this is not required.*</p> <p>First Meeting Agenda:<br/>- Event starts at 6:00 PM<br/>- Food and informal introductions<br/>- Update on housing projects<br/>- Break into teams and hack on housing web projects.<br/>- Wrap up at 7:30 PM</p> <p>Much thanks to our amazing sponsor Hack Upstate. Check out what they are up to at <a href=\"https://hackupstate.com\" class=\"linkified\">https://hackupstate.com</a> Also, special thanks to Syracuse CoWorks for letting us use their awesome space. Check them out at <a href=\"http://www.syracusecoworks.com\" class=\"linkified\">http://www.syracusecoworks.com</a>.</p> <p>To find out more information on our current projects, join our Slack Channel at: <a href=\"https://slackacuse.herokuapp.com/\" class=\"linkified\">https://slackacuse.herokuapp.com/</a> where we are currently collaborating in the #code_for_syracuse thread.</p> "
+  },
+  {
+    "name": "OpenHack: Code together, on anything.",
+    "local_date": "2019-10-08",
+    "local_time": "18:00",
+    "link": "https://www.meetup.com/Syracuse-Software-Development-Meetup/events/gdqxgpyznblb/",
+    "description": "<p>• What we'll do<br/>OpenHack is a casual social coding meetup with a simple purpose: Code together, on anything.</p> <p>We welcome local developers and designers of all skill levels, interests, ages genders, you-name-it to get together to write code or push pixels. We’ll provide good food, good people, and creative energy.</p> <p>Here’s how OpenHack works:</p> <p>* You can hack on anything! Any language, framework, public/open-source, personal projects, client work… anything!<br/>* You don’t have to have an idea to hack on, you can come join someone else<br/>* We’ll kick things off with a quick round of introductions, to say who you are, what you’re working on, and if you’d like help with your idea<br/>* Food and drinks will be provided<br/>* Feel free to join us - bring a laptop, a project, and a friend!</p> <p>See more at <a href=\"http://openhacksyr.com\" class=\"linkified\">http://openhacksyr.com</a></p> <p>• What to bring<br/>A laptop if you're bringing a project, but not required</p> <p>• Important to know<br/>Please review our Code of Conduct before attending: <a href=\"http://openhacksyr.com/code_of_conduct/\" class=\"linkified\">http://openhacksyr.com/code_of_conduct/</a></p> "
+  },
+  {
+    "name": "Women in Coding - Monthly Workshop",
+    "local_date": "2019-10-12",
+    "local_time": "10:00",
+    "link": "https://www.meetup.com/Syracuse-Software-Development-Meetup/events/rbmxbryznbqb/",
+    "description": "<p>• What we'll do<br/>Women in Coding will be hosting workshop style classes once a month every second Saturday of the month, from 10am-12pm at The Tech Garden! Rather than having an instructor teach a specific topic, these workshops will give you the chance to work on a project or work through an online curriculum at your own pace. Never coded before? No problem. We'll help get you started. Each workshop will have at least one mentor there to provide support and answer questions.</p> <p>• What to bring<br/>Bring your computer, questions and/or a project</p> <p>• Important to know<br/>This month's mentors are:<br/>Ashley Oliver and Jennifer Tran experienced in Cyber Security, Data Science, and Blockchain</p> <p>Skills/Knowledge: Cyber Security, IT Security, InfoSec, Network Security, Splunk, SIEM, NGFW, Fortinet, Checkpoint, Juniper, Cisco, Palo Alto, Redhat Linux, FortiAnalyzer, FortiManager, Panorama, SmartDashBoard, Tufin, Algosec, TCP/IP, IPS/IDS, Route/Switch, Data science, and Blockchain<br/>Languages: R and JavaScript</p> <p>Big thank you to Hack Upstate for sponsoring our meetups. You can learn more about them at <a href=\"http://hackupstate.com/\" class=\"linkified\">http://hackupstate.com/</a>.</p> "
+  },
+  {
+    "name": "Coffee & Code",
+    "local_date": "2019-10-13",
+    "local_time": "11:00",
+    "link": "https://www.meetup.com/Syracuse-Software-Development-Meetup/events/265429497/",
+    "description": "<p>Stop by for some Sunday morning coffee and coding!</p> <p>This is a general topic/networking event, nothing language-specific. Just bring yourself, something to code on, and enjoy some coffee with (new) friends!</p> <p>Also, it's October, so if you're participating in Hacktoberfest, stop down and share with us what you're doing or if you need any help!</p> <p>There's only room for about 10 or so people in the Community Room at this location, but there's more seating in the general cafe area as well. The Community Room has a large screen with a HDMI hookup and an array of outlets for plugging in, so it can be used for presenting/teaching/etc.</p> "
+  },
+  {
+    "name": "Technology Learning Day Conference by Major League Hacking",
+    "local_date": "2019-10-19",
+    "local_time": "08:00",
+    "link": "https://www.meetup.com/Syracuse-Software-Development-Meetup/events/265639558/",
+    "description": "<p>MLH's technology learning day conference is a global conference that allows the community to pick up new skills by experiencing a professional day of learning first-hand. Over the course of the day attendees will participate in a series of workshops where they’ll learn skills such as publishing their first website using AWS, sending their first SMS with Twilio, Blockchain, building their first game in Unity and more. This conference is for high schoolers, college students, coding newcomers, and technology professionals who want to know more about the world of technology from industry experts.</p> <p>MLH's Local Hack Day is a series of simultaneous global events designed to spark a passion for technology in your local community. Spend the day getting hands-on experience and collaborating in a welcoming environment. Whether you are learning to code or are an expert hacker, Local Hack Day is perfect for you and your community. Learn new skills, build new projects, and share your creations.</p> <p>Talk schedule is currently TBD but we'll promise talks on web development, blockchain, game development, and more! The conference talks will start at 9AM and will continue to 7PM but you may come and go as you wish!</p> <p>This event is being held at one of Syracuse's newest premier co-working spaces... ShareCuse. Your attendance gives you first peek at what it would be like to be a part of the downtown Syracuse co-working scene for your business, personal projects, and freelancing needs.</p> "
+  },
+  {
+    "name": "Code for Syracuse Monthly Hack Night",
+    "local_date": "2019-10-22",
+    "local_time": "18:00",
+    "link": "https://www.meetup.com/Syracuse-Software-Development-Meetup/events/265683581/",
+    "description": "<p>Join us for our monthly night of Civic Hacking where we are currently working together on web-based projects related to housing issues in the Syracuse area.</p> <p>Code for Syracuse is a group of technologists with a simple purpose, work together on things that matter. We are partnering with local non-profits and local government build a better Syracuse for everyone. That means we need everyone: community leaders and coders, subject-matter experts and project managers, activists and designers, public servants and curious residents.</p> <p>*You should bring your laptop*</p> <p>First Meeting Agenda:<br/>- Event starts at 6:00 PM<br/>- Food and informal introductions<br/>- Introduction to Tableau Public by Amanda Darcangelo of Salt City Analytics, Project Lead of data visualization Group</p> <p>- Update on housing projects<br/>- Break into teams and hack on housing web projects.<br/>- Wrap up at 7:30 PM</p> <p>Much thanks to our amazing sponsor Hack Upstate. Check out what they are up to at <a href=\"https://hackupstate.com\" class=\"linkified\">https://hackupstate.com</a> Also, special thanks to Syracuse CoWorks for letting us use their awesome space. Check them out at <a href=\"http://www.syracusecoworks.com\" class=\"linkified\">http://www.syracusecoworks.com</a>.</p> <p>To find out more information on our current projects, join our Slack Channel at: <a href=\"https://slackacuse.herokuapp.com/\" class=\"linkified\">https://slackacuse.herokuapp.com/</a> where we are currently collaborating in the #code_for_syracuse thread.</p> "
+  },
+  {
+    "name": "Syracuse JavaScript Meetup | Topic: Hacktoberfest",
+    "local_date": "2019-10-29",
+    "local_time": "18:00",
+    "link": "https://www.meetup.com/Syracuse-Software-Development-Meetup/events/jccphryznbtb/",
+    "description": "<p>We are a group dedicated to discussing and working with the JavaScript programming language.</p> <p>Currently we meet the third Tuesday of each month (this month its the fifth Tuesday - October 29), and each event has both a learning and interactive portion. Whether you’re an experienced JavaScript programmer or just getting started, we welcome and encourage all proficiency levels.</p> <p>Each month we'll be exploring the \"Current Topic\" referenced in the Meetup title. If you're not familiar with the topic, come learn something new! Already a pro? Awesome! We can use some mentors to help out with questions. Check us out for some great discussions, food, and drink!</p> <p>• What to bring<br/>Laptop</p> <p>• Important to know<br/>Harassment-free meetup, regardless of topic</p> "
+  },
+  {
+    "name": "Women in Coding - Monthly Workshop",
+    "local_date": "2019-11-09",
+    "local_time": "10:00",
+    "link": "https://www.meetup.com/Syracuse-Software-Development-Meetup/events/rbmxbryzpbmb/",
+    "description": "<p>• What we'll do<br/>Women in Coding will be hosting workshop style classes once a month every second Saturday of the month, from 10am-12pm at The Tech Garden! Rather than having an instructor teach a specific topic, these workshops will give you the chance to work on a project or work through an online curriculum at your own pace. Never coded before? No problem. We'll help get you started. Each workshop will have at least one mentor there to provide support and answer questions.</p> <p>• What to bring<br/>Bring your computer, questions and/or a project</p> <p>• Important to know<br/>This month's mentors and their skills are TBD. Check for updates.</p> <p>Big thank you to Hack Upstate for sponsoring our meetups. You can learn more about them at <a href=\"http://hackupstate.com/\" class=\"linkified\">http://hackupstate.com/</a>.</p> "
+  },
+  {
+    "name": "OpenHack: Code together, on anything.",
+    "local_date": "2019-11-12",
+    "local_time": "18:00",
+    "link": "https://www.meetup.com/Syracuse-Software-Development-Meetup/events/gdqxgpyzpbqb/",
+    "description": "<p>• What we'll do<br/>OpenHack is a casual social coding meetup with a simple purpose: Code together, on anything.</p> <p>We welcome local developers and designers of all skill levels, interests, ages genders, you-name-it to get together to write code or push pixels. We’ll provide good food, good people, and creative energy.</p> <p>Here’s how OpenHack works:</p> <p>* You can hack on anything! Any language, framework, public/open-source, personal projects, client work… anything!<br/>* You don’t have to have an idea to hack on, you can come join someone else<br/>* We’ll kick things off with a quick round of introductions, to say who you are, what you’re working on, and if you’d like help with your idea<br/>* Food and drinks will be provided<br/>* Feel free to join us - bring a laptop, a project, and a friend!</p> <p>See more at <a href=\"http://openhacksyr.com\" class=\"linkified\">http://openhacksyr.com</a></p> <p>• What to bring<br/>A laptop if you're bringing a project, but not required</p> <p>• Important to know<br/>Please review our Code of Conduct before attending: <a href=\"http://openhacksyr.com/code_of_conduct/\" class=\"linkified\">http://openhacksyr.com/code_of_conduct/</a></p> "
+  },
+  {
+    "name": "Syracuse JavaScript Meetup | Topic: TBD",
+    "local_date": "2019-11-19",
+    "local_time": "18:00",
+    "link": "https://www.meetup.com/Syracuse-Software-Development-Meetup/events/jccphryzpbzb/",
+    "description": "<p>We are a group dedicated to discussing and working with the JavaScript programming language.</p> <p>Currently we meet the third Tuesday of each month, and each event has both a learning and interactive portion. Whether you’re an experienced JavaScript programmer or just getting started, we welcome and encourage all proficiency levels.</p> <p>Each month we'll be exploring the \"Current Topic\" referenced in the Meetup title. If you're not familiar with the topic, come learn something new! Already a pro? Awesome! We can use some mentors to help out with questions. Check us out for some great discussions, food, and drink!</p> <p>• What to bring<br/>Laptop</p> <p>• Important to know<br/>Harassment-free meetup, regardless of topic</p> "
+  },
+  {
+    "name": "OpenHack: Code together, on anything.",
+    "local_date": "2019-12-10",
+    "local_time": "18:00",
+    "link": "https://www.meetup.com/Syracuse-Software-Development-Meetup/events/gdqxgpyzqbnb/",
+    "description": "<p>• What we'll do<br/>OpenHack is a casual social coding meetup with a simple purpose: Code together, on anything.</p> <p>We welcome local developers and designers of all skill levels, interests, ages genders, you-name-it to get together to write code or push pixels. We’ll provide good food, good people, and creative energy.</p> <p>Here’s how OpenHack works:</p> <p>* You can hack on anything! Any language, framework, public/open-source, personal projects, client work… anything!<br/>* You don’t have to have an idea to hack on, you can come join someone else<br/>* We’ll kick things off with a quick round of introductions, to say who you are, what you’re working on, and if you’d like help with your idea<br/>* Food and drinks will be provided<br/>* Feel free to join us - bring a laptop, a project, and a friend!</p> <p>See more at <a href=\"http://openhacksyr.com\" class=\"linkified\">http://openhacksyr.com</a></p> <p>• What to bring<br/>A laptop if you're bringing a project, but not required</p> <p>• Important to know<br/>Please review our Code of Conduct before attending: <a href=\"http://openhacksyr.com/code_of_conduct/\" class=\"linkified\">http://openhacksyr.com/code_of_conduct/</a></p> "
+  },
+  {
+    "name": "Women in Coding - Monthly Workshop",
+    "local_date": "2019-12-14",
+    "local_time": "10:00",
+    "link": "https://www.meetup.com/Syracuse-Software-Development-Meetup/events/rbmxbryzqbsb/",
+    "description": "<p>• What we'll do<br/>Women in Coding will be hosting workshop style classes once a month every second Saturday of the month, from 10am-12pm at The Tech Garden! Rather than having an instructor teach a specific topic, these workshops will give you the chance to work on a project or work through an online curriculum at your own pace. Never coded before? No problem. We'll help get you started. Each workshop will have at least one mentor there to provide support and answer questions.</p> <p>• What to bring<br/>Bring your computer, questions and/or a project</p> <p>• Important to know<br/>This month's mentors and their skills are TBD. Check for updates.</p> <p>Big thank you to Hack Upstate for sponsoring our meetups. You can learn more about them at <a href=\"http://hackupstate.com/\" class=\"linkified\">http://hackupstate.com/</a>.</p> "
+  },
+  {
+    "name": "Syracuse JavaScript Meetup | Topic: TBD",
+    "local_date": "2019-12-17",
+    "local_time": "18:00",
+    "link": "https://www.meetup.com/Syracuse-Software-Development-Meetup/events/jccphryzqbwb/",
+    "description": "<p>We are a group dedicated to discussing and working with the JavaScript programming language.</p> <p>Currently we meet the third Tuesday of each month, and each event has both a learning and interactive portion. Whether you’re an experienced JavaScript programmer or just getting started, we welcome and encourage all proficiency levels.</p> <p>Each month we'll be exploring the \"Current Topic\" referenced in the Meetup title. If you're not familiar with the topic, come learn something new! Already a pro? Awesome! We can use some mentors to help out with questions. Check us out for some great discussions, food, and drink!</p> <p>• What to bring<br/>Laptop</p> <p>• Important to know<br/>Harassment-free meetup, regardless of topic</p> "
+  },
+  {
+    "name": "Women in Coding - Monthly Workshop",
+    "local_date": "2020-01-11",
+    "local_time": "10:00",
+    "link": "https://www.meetup.com/Syracuse-Software-Development-Meetup/events/rbmxbrybccbpb/",
+    "description": "<p>• What we'll do<br/>Women in Coding will be hosting workshop style classes once a month every second Saturday of the month, from 10am-12pm at The Tech Garden! Rather than having an instructor teach a specific topic, these workshops will give you the chance to work on a project or work through an online curriculum at your own pace. Never coded before? No problem. We'll help get you started. Each workshop will have at least one mentor there to provide support and answer questions.</p> <p>• What to bring<br/>Bring your computer, questions and/or a project</p> <p>• Important to know<br/>This month's mentors and their skills are TBD. Check for updates.</p> <p>Big thank you to Hack Upstate for sponsoring our meetups. You can learn more about them at <a href=\"http://hackupstate.com/\" class=\"linkified\">http://hackupstate.com/</a>.</p> "
+  },
+  {
+    "name": "OpenHack: Code together, on anything.",
+    "local_date": "2020-01-14",
+    "local_time": "18:00",
+    "link": "https://www.meetup.com/Syracuse-Software-Development-Meetup/events/gdqxgpybccbsb/",
+    "description": "<p>• What we'll do<br/>OpenHack is a casual social coding meetup with a simple purpose: Code together, on anything.</p> <p>We welcome local developers and designers of all skill levels, interests, ages genders, you-name-it to get together to write code or push pixels. We’ll provide good food, good people, and creative energy.</p> <p>Here’s how OpenHack works:</p> <p>* You can hack on anything! Any language, framework, public/open-source, personal projects, client work… anything!<br/>* You don’t have to have an idea to hack on, you can come join someone else<br/>* We’ll kick things off with a quick round of introductions, to say who you are, what you’re working on, and if you’d like help with your idea<br/>* Food and drinks will be provided<br/>* Feel free to join us - bring a laptop, a project, and a friend!</p> <p>See more at <a href=\"http://openhacksyr.com\" class=\"linkified\">http://openhacksyr.com</a></p> <p>• What to bring<br/>A laptop if you're bringing a project, but not required</p> <p>• Important to know<br/>Please review our Code of Conduct before attending: <a href=\"http://openhacksyr.com/code_of_conduct/\" class=\"linkified\">http://openhacksyr.com/code_of_conduct/</a></p> "
+  },
+  {
+    "name": "Syracuse JavaScript Meetup | Topic: TBD",
+    "local_date": "2020-01-21",
+    "local_time": "18:00",
+    "link": "https://www.meetup.com/Syracuse-Software-Development-Meetup/events/jccphrybccbcc/",
+    "description": "<p>We are a group dedicated to discussing and working with the JavaScript programming language.</p> <p>Currently we meet the third Tuesday of each month, and each event has both a learning and interactive portion. Whether you’re an experienced JavaScript programmer or just getting started, we welcome and encourage all proficiency levels.</p> <p>Each month we'll be exploring the \"Current Topic\" referenced in the Meetup title. If you're not familiar with the topic, come learn something new! Already a pro? Awesome! We can use some mentors to help out with questions. Check us out for some great discussions, food, and drink!</p> <p>• What to bring<br/>Laptop</p> <p>• Important to know<br/>Harassment-free meetup, regardless of topic</p> "
+  },
+  {
+    "name": "Women in Coding - Monthly Workshop",
+    "local_date": "2020-02-08",
+    "local_time": "10:00",
+    "link": "https://www.meetup.com/Syracuse-Software-Development-Meetup/events/rbmxbrybcdblb/",
+    "description": "<p>• What we'll do<br/>Women in Coding will be hosting workshop style classes once a month every second Saturday of the month, from 10am-12pm at The Tech Garden! Rather than having an instructor teach a specific topic, these workshops will give you the chance to work on a project or work through an online curriculum at your own pace. Never coded before? No problem. We'll help get you started. Each workshop will have at least one mentor there to provide support and answer questions.</p> <p>• What to bring<br/>Bring your computer, questions and/or a project</p> <p>• Important to know<br/>This month's mentors and their skills are TBD. Check for updates.</p> <p>Big thank you to Hack Upstate for sponsoring our meetups. You can learn more about them at <a href=\"http://hackupstate.com/\" class=\"linkified\">http://hackupstate.com/</a>.</p> "
+  },
+  {
+    "name": "OpenHack: Code together, on anything.",
+    "local_date": "2020-02-11",
+    "local_time": "18:00",
+    "link": "https://www.meetup.com/Syracuse-Software-Development-Meetup/events/gdqxgpybcdbpb/",
+    "description": "<p>• What we'll do<br/>OpenHack is a casual social coding meetup with a simple purpose: Code together, on anything.</p> <p>We welcome local developers and designers of all skill levels, interests, ages genders, you-name-it to get together to write code or push pixels. We’ll provide good food, good people, and creative energy.</p> <p>Here’s how OpenHack works:</p> <p>* You can hack on anything! Any language, framework, public/open-source, personal projects, client work… anything!<br/>* You don’t have to have an idea to hack on, you can come join someone else<br/>* We’ll kick things off with a quick round of introductions, to say who you are, what you’re working on, and if you’d like help with your idea<br/>* Food and drinks will be provided<br/>* Feel free to join us - bring a laptop, a project, and a friend!</p> <p>See more at <a href=\"http://openhacksyr.com\" class=\"linkified\">http://openhacksyr.com</a></p> <p>• What to bring<br/>A laptop if you're bringing a project, but not required</p> <p>• Important to know<br/>Please review our Code of Conduct before attending: <a href=\"http://openhacksyr.com/code_of_conduct/\" class=\"linkified\">http://openhacksyr.com/code_of_conduct/</a></p> "
+  },
+  {
+    "name": "Syracuse JavaScript Meetup | Topic: TBD",
+    "local_date": "2020-02-18",
+    "local_time": "18:00",
+    "link": "https://www.meetup.com/Syracuse-Software-Development-Meetup/events/jccphrybcdbxb/",
+    "description": "<p>We are a group dedicated to discussing and working with the JavaScript programming language.</p> <p>Currently we meet the third Tuesday of each month, and each event has both a learning and interactive portion. Whether you’re an experienced JavaScript programmer or just getting started, we welcome and encourage all proficiency levels.</p> <p>Each month we'll be exploring the \"Current Topic\" referenced in the Meetup title. If you're not familiar with the topic, come learn something new! Already a pro? Awesome! We can use some mentors to help out with questions. Check us out for some great discussions, food, and drink!</p> <p>• What to bring<br/>Laptop</p> <p>• Important to know<br/>Harassment-free meetup, regardless of topic</p> "
+  },
+  {
+    "name": "OpenHack: Code together, on anything.",
+    "local_date": "2020-03-10",
+    "local_time": "18:00",
+    "link": "https://www.meetup.com/Syracuse-Software-Development-Meetup/events/gdqxgpybcfbnb/",
+    "description": "<p>• What we'll do<br/>OpenHack is a casual social coding meetup with a simple purpose: Code together, on anything.</p> <p>We welcome local developers and designers of all skill levels, interests, ages genders, you-name-it to get together to write code or push pixels. We’ll provide good food, good people, and creative energy.</p> <p>Here’s how OpenHack works:</p> <p>* You can hack on anything! Any language, framework, public/open-source, personal projects, client work… anything!<br/>* You don’t have to have an idea to hack on, you can come join someone else<br/>* We’ll kick things off with a quick round of introductions, to say who you are, what you’re working on, and if you’d like help with your idea<br/>* Food and drinks will be provided<br/>* Feel free to join us - bring a laptop, a project, and a friend!</p> <p>See more at <a href=\"http://openhacksyr.com\" class=\"linkified\">http://openhacksyr.com</a></p> <p>• What to bring<br/>A laptop if you're bringing a project, but not required</p> <p>• Important to know<br/>Please review our Code of Conduct before attending: <a href=\"http://openhacksyr.com/code_of_conduct/\" class=\"linkified\">http://openhacksyr.com/code_of_conduct/</a></p> "
+  },
+  {
+    "name": "Women in Coding - Monthly Workshop",
+    "local_date": "2020-03-14",
+    "local_time": "10:00",
+    "link": "https://www.meetup.com/Syracuse-Software-Development-Meetup/events/rbmxbrybcfbsb/",
+    "description": "<p>• What we'll do<br/>Women in Coding will be hosting workshop style classes once a month every second Saturday of the month, from 10am-12pm at The Tech Garden! Rather than having an instructor teach a specific topic, these workshops will give you the chance to work on a project or work through an online curriculum at your own pace. Never coded before? No problem. We'll help get you started. Each workshop will have at least one mentor there to provide support and answer questions.</p> <p>• What to bring<br/>Bring your computer, questions and/or a project</p> <p>• Important to know<br/>This month's mentors and their skills are TBD. Check for updates.</p> <p>Big thank you to Hack Upstate for sponsoring our meetups. You can learn more about them at <a href=\"http://hackupstate.com/\" class=\"linkified\">http://hackupstate.com/</a>.</p> "
+  },
+  {
+    "name": "Syracuse JavaScript Meetup | Topic: TBD",
+    "local_date": "2020-03-17",
+    "local_time": "18:00",
+    "link": "https://www.meetup.com/Syracuse-Software-Development-Meetup/events/jccphrybcfbwb/",
+    "description": "<p>We are a group dedicated to discussing and working with the JavaScript programming language.</p> <p>Currently we meet the third Tuesday of each month, and each event has both a learning and interactive portion. Whether you’re an experienced JavaScript programmer or just getting started, we welcome and encourage all proficiency levels.</p> <p>Each month we'll be exploring the \"Current Topic\" referenced in the Meetup title. If you're not familiar with the topic, come learn something new! Already a pro? Awesome! We can use some mentors to help out with questions. Check us out for some great discussions, food, and drink!</p> <p>• What to bring<br/>Laptop</p> <p>• Important to know<br/>Harassment-free meetup, regardless of topic</p> "
+  },
+  {
+    "name": "Women in Coding - Monthly Workshop",
+    "local_date": "2020-04-11",
+    "local_time": "10:00",
+    "link": "https://www.meetup.com/Syracuse-Software-Development-Meetup/events/rbmxbrybcgbpb/",
+    "description": "<p>• What we'll do<br/>Women in Coding will be hosting workshop style classes once a month every second Saturday of the month, from 10am-12pm at The Tech Garden! Rather than having an instructor teach a specific topic, these workshops will give you the chance to work on a project or work through an online curriculum at your own pace. Never coded before? No problem. We'll help get you started. Each workshop will have at least one mentor there to provide support and answer questions.</p> <p>• What to bring<br/>Bring your computer, questions and/or a project</p> <p>• Important to know<br/>This month's mentors and their skills are TBD. Check for updates.</p> <p>Big thank you to Hack Upstate for sponsoring our meetups. You can learn more about them at <a href=\"http://hackupstate.com/\" class=\"linkified\">http://hackupstate.com/</a>.</p> "
+  },
+  {
+    "name": "OpenHack: Code together, on anything.",
+    "local_date": "2020-04-14",
+    "local_time": "18:00",
+    "link": "https://www.meetup.com/Syracuse-Software-Development-Meetup/events/gdqxgpybcgbsb/",
+    "description": "<p>• What we'll do<br/>OpenHack is a casual social coding meetup with a simple purpose: Code together, on anything.</p> <p>We welcome local developers and designers of all skill levels, interests, ages genders, you-name-it to get together to write code or push pixels. We’ll provide good food, good people, and creative energy.</p> <p>Here’s how OpenHack works:</p> <p>* You can hack on anything! Any language, framework, public/open-source, personal projects, client work… anything!<br/>* You don’t have to have an idea to hack on, you can come join someone else<br/>* We’ll kick things off with a quick round of introductions, to say who you are, what you’re working on, and if you’d like help with your idea<br/>* Food and drinks will be provided<br/>* Feel free to join us - bring a laptop, a project, and a friend!</p> <p>See more at <a href=\"http://openhacksyr.com\" class=\"linkified\">http://openhacksyr.com</a></p> <p>• What to bring<br/>A laptop if you're bringing a project, but not required</p> <p>• Important to know<br/>Please review our Code of Conduct before attending: <a href=\"http://openhacksyr.com/code_of_conduct/\" class=\"linkified\">http://openhacksyr.com/code_of_conduct/</a></p> "
+  },
+  {
+    "name": "Syracuse JavaScript Meetup | Topic: TBD",
+    "local_date": "2020-04-21",
+    "local_time": "18:00",
+    "link": "https://www.meetup.com/Syracuse-Software-Development-Meetup/events/jccphrybcgbcc/",
+    "description": "<p>We are a group dedicated to discussing and working with the JavaScript programming language.</p> <p>Currently we meet the third Tuesday of each month, and each event has both a learning and interactive portion. Whether you’re an experienced JavaScript programmer or just getting started, we welcome and encourage all proficiency levels.</p> <p>Each month we'll be exploring the \"Current Topic\" referenced in the Meetup title. If you're not familiar with the topic, come learn something new! Already a pro? Awesome! We can use some mentors to help out with questions. Check us out for some great discussions, food, and drink!</p> <p>• What to bring<br/>Laptop</p> <p>• Important to know<br/>Harassment-free meetup, regardless of topic</p> "
+  },
+  {
+    "name": "Women in Coding - Monthly Workshop",
+    "local_date": "2020-05-09",
+    "local_time": "10:00",
+    "link": "https://www.meetup.com/Syracuse-Software-Development-Meetup/events/rbmxbrybchbmb/",
+    "description": "<p>• What we'll do<br/>Women in Coding will be hosting workshop style classes once a month every second Saturday of the month, from 10am-12pm at The Tech Garden! Rather than having an instructor teach a specific topic, these workshops will give you the chance to work on a project or work through an online curriculum at your own pace. Never coded before? No problem. We'll help get you started. Each workshop will have at least one mentor there to provide support and answer questions.</p> <p>• What to bring<br/>Bring your computer, questions and/or a project</p> <p>• Important to know<br/>This month's mentors and their skills are TBD. Check for updates.</p> <p>Big thank you to Hack Upstate for sponsoring our meetups. You can learn more about them at <a href=\"http://hackupstate.com/\" class=\"linkified\">http://hackupstate.com/</a>.</p> "
+  },
+  {
+    "name": "OpenHack: Code together, on anything.",
+    "local_date": "2020-05-12",
+    "local_time": "18:00",
+    "link": "https://www.meetup.com/Syracuse-Software-Development-Meetup/events/gdqxgpybchbqb/",
+    "description": "<p>• What we'll do<br/>OpenHack is a casual social coding meetup with a simple purpose: Code together, on anything.</p> <p>We welcome local developers and designers of all skill levels, interests, ages genders, you-name-it to get together to write code or push pixels. We’ll provide good food, good people, and creative energy.</p> <p>Here’s how OpenHack works:</p> <p>* You can hack on anything! Any language, framework, public/open-source, personal projects, client work… anything!<br/>* You don’t have to have an idea to hack on, you can come join someone else<br/>* We’ll kick things off with a quick round of introductions, to say who you are, what you’re working on, and if you’d like help with your idea<br/>* Food and drinks will be provided<br/>* Feel free to join us - bring a laptop, a project, and a friend!</p> <p>See more at <a href=\"http://openhacksyr.com\" class=\"linkified\">http://openhacksyr.com</a></p> <p>• What to bring<br/>A laptop if you're bringing a project, but not required</p> <p>• Important to know<br/>Please review our Code of Conduct before attending: <a href=\"http://openhacksyr.com/code_of_conduct/\" class=\"linkified\">http://openhacksyr.com/code_of_conduct/</a></p> "
+  },
+  {
+    "name": "Syracuse JavaScript Meetup | Topic: TBD",
+    "local_date": "2020-05-19",
+    "local_time": "18:00",
+    "link": "https://www.meetup.com/Syracuse-Software-Development-Meetup/events/jccphrybchbzb/",
+    "description": "<p>We are a group dedicated to discussing and working with the JavaScript programming language.</p> <p>Currently we meet the third Tuesday of each month, and each event has both a learning and interactive portion. Whether you’re an experienced JavaScript programmer or just getting started, we welcome and encourage all proficiency levels.</p> <p>Each month we'll be exploring the \"Current Topic\" referenced in the Meetup title. If you're not familiar with the topic, come learn something new! Already a pro? Awesome! We can use some mentors to help out with questions. Check us out for some great discussions, food, and drink!</p> <p>• What to bring<br/>Laptop</p> <p>• Important to know<br/>Harassment-free meetup, regardless of topic</p> "
+  },
+  {
+    "name": "OpenHack: Code together, on anything.",
+    "local_date": "2020-06-09",
+    "local_time": "18:00",
+    "link": "https://www.meetup.com/Syracuse-Software-Development-Meetup/events/gdqxgpybcjbmb/",
+    "description": "<p>• What we'll do<br/>OpenHack is a casual social coding meetup with a simple purpose: Code together, on anything.</p> <p>We welcome local developers and designers of all skill levels, interests, ages genders, you-name-it to get together to write code or push pixels. We’ll provide good food, good people, and creative energy.</p> <p>Here’s how OpenHack works:</p> <p>* You can hack on anything! Any language, framework, public/open-source, personal projects, client work… anything!<br/>* You don’t have to have an idea to hack on, you can come join someone else<br/>* We’ll kick things off with a quick round of introductions, to say who you are, what you’re working on, and if you’d like help with your idea<br/>* Food and drinks will be provided<br/>* Feel free to join us - bring a laptop, a project, and a friend!</p> <p>See more at <a href=\"http://openhacksyr.com\" class=\"linkified\">http://openhacksyr.com</a></p> <p>• What to bring<br/>A laptop if you're bringing a project, but not required</p> <p>• Important to know<br/>Please review our Code of Conduct before attending: <a href=\"http://openhacksyr.com/code_of_conduct/\" class=\"linkified\">http://openhacksyr.com/code_of_conduct/</a></p> "
+  },
+  {
+    "name": "Women in Coding - Monthly Workshop",
+    "local_date": "2020-06-13",
+    "local_time": "10:00",
+    "link": "https://www.meetup.com/Syracuse-Software-Development-Meetup/events/rbmxbrybcjbrb/",
+    "description": "<p>• What we'll do<br/>Women in Coding will be hosting workshop style classes once a month every second Saturday of the month, from 10am-12pm at The Tech Garden! Rather than having an instructor teach a specific topic, these workshops will give you the chance to work on a project or work through an online curriculum at your own pace. Never coded before? No problem. We'll help get you started. Each workshop will have at least one mentor there to provide support and answer questions.</p> <p>• What to bring<br/>Bring your computer, questions and/or a project</p> <p>• Important to know<br/>This month's mentors and their skills are TBD. Check for updates.</p> <p>Big thank you to Hack Upstate for sponsoring our meetups. You can learn more about them at <a href=\"http://hackupstate.com/\" class=\"linkified\">http://hackupstate.com/</a>.</p> "
+  },
+  {
+    "name": "Syracuse JavaScript Meetup | Topic: TBD",
+    "local_date": "2020-06-16",
+    "local_time": "18:00",
+    "link": "https://www.meetup.com/Syracuse-Software-Development-Meetup/events/jccphrybcjbvb/",
+    "description": "<p>We are a group dedicated to discussing and working with the JavaScript programming language.</p> <p>Currently we meet the third Tuesday of each month, and each event has both a learning and interactive portion. Whether you’re an experienced JavaScript programmer or just getting started, we welcome and encourage all proficiency levels.</p> <p>Each month we'll be exploring the \"Current Topic\" referenced in the Meetup title. If you're not familiar with the topic, come learn something new! Already a pro? Awesome! We can use some mentors to help out with questions. Check us out for some great discussions, food, and drink!</p> <p>• What to bring<br/>Laptop</p> <p>• Important to know<br/>Harassment-free meetup, regardless of topic</p> "
+  },
+  {
+    "name": "Women in Coding - Monthly Workshop",
+    "local_date": "2020-07-11",
+    "local_time": "10:00",
+    "link": "https://www.meetup.com/Syracuse-Software-Development-Meetup/events/rbmxbrybckbpb/",
+    "description": "<p>• What we'll do<br/>Women in Coding will be hosting workshop style classes once a month every second Saturday of the month, from 10am-12pm at The Tech Garden! Rather than having an instructor teach a specific topic, these workshops will give you the chance to work on a project or work through an online curriculum at your own pace. Never coded before? No problem. We'll help get you started. Each workshop will have at least one mentor there to provide support and answer questions.</p> <p>• What to bring<br/>Bring your computer, questions and/or a project</p> <p>• Important to know<br/>This month's mentors and their skills are TBD. Check for updates.</p> <p>Big thank you to Hack Upstate for sponsoring our meetups. You can learn more about them at <a href=\"http://hackupstate.com/\" class=\"linkified\">http://hackupstate.com/</a>.</p> "
+  },
+  {
+    "name": "OpenHack: Code together, on anything.",
+    "local_date": "2020-07-14",
+    "local_time": "18:00",
+    "link": "https://www.meetup.com/Syracuse-Software-Development-Meetup/events/gdqxgpybckbsb/",
+    "description": "<p>• What we'll do<br/>OpenHack is a casual social coding meetup with a simple purpose: Code together, on anything.</p> <p>We welcome local developers and designers of all skill levels, interests, ages genders, you-name-it to get together to write code or push pixels. We’ll provide good food, good people, and creative energy.</p> <p>Here’s how OpenHack works:</p> <p>* You can hack on anything! Any language, framework, public/open-source, personal projects, client work… anything!<br/>* You don’t have to have an idea to hack on, you can come join someone else<br/>* We’ll kick things off with a quick round of introductions, to say who you are, what you’re working on, and if you’d like help with your idea<br/>* Food and drinks will be provided<br/>* Feel free to join us - bring a laptop, a project, and a friend!</p> <p>See more at <a href=\"http://openhacksyr.com\" class=\"linkified\">http://openhacksyr.com</a></p> <p>• What to bring<br/>A laptop if you're bringing a project, but not required</p> <p>• Important to know<br/>Please review our Code of Conduct before attending: <a href=\"http://openhacksyr.com/code_of_conduct/\" class=\"linkified\">http://openhacksyr.com/code_of_conduct/</a></p> "
+  },
+  {
+    "name": "Syracuse JavaScript Meetup | Topic: TBD",
+    "local_date": "2020-07-21",
+    "local_time": "18:00",
+    "link": "https://www.meetup.com/Syracuse-Software-Development-Meetup/events/jccphrybckbcc/",
+    "description": "<p>We are a group dedicated to discussing and working with the JavaScript programming language.</p> <p>Currently we meet the third Tuesday of each month, and each event has both a learning and interactive portion. Whether you’re an experienced JavaScript programmer or just getting started, we welcome and encourage all proficiency levels.</p> <p>Each month we'll be exploring the \"Current Topic\" referenced in the Meetup title. If you're not familiar with the topic, come learn something new! Already a pro? Awesome! We can use some mentors to help out with questions. Check us out for some great discussions, food, and drink!</p> <p>• What to bring<br/>Laptop</p> <p>• Important to know<br/>Harassment-free meetup, regardless of topic</p> "
+  },
+  {
+    "name": "Women in Coding - Monthly Workshop",
+    "local_date": "2020-08-08",
+    "local_time": "10:00",
+    "link": "https://www.meetup.com/Syracuse-Software-Development-Meetup/events/rbmxbrybclblb/",
+    "description": "<p>• What we'll do<br/>Women in Coding will be hosting workshop style classes once a month every second Saturday of the month, from 10am-12pm at The Tech Garden! Rather than having an instructor teach a specific topic, these workshops will give you the chance to work on a project or work through an online curriculum at your own pace. Never coded before? No problem. We'll help get you started. Each workshop will have at least one mentor there to provide support and answer questions.</p> <p>• What to bring<br/>Bring your computer, questions and/or a project</p> <p>• Important to know<br/>This month's mentors and their skills are TBD. Check for updates.</p> <p>Big thank you to Hack Upstate for sponsoring our meetups. You can learn more about them at <a href=\"http://hackupstate.com/\" class=\"linkified\">http://hackupstate.com/</a>.</p> "
+  },
+  {
+    "name": "OpenHack: Code together, on anything.",
+    "local_date": "2020-08-11",
+    "local_time": "18:00",
+    "link": "https://www.meetup.com/Syracuse-Software-Development-Meetup/events/gdqxgpybclbpb/",
+    "description": "<p>• What we'll do<br/>OpenHack is a casual social coding meetup with a simple purpose: Code together, on anything.</p> <p>We welcome local developers and designers of all skill levels, interests, ages genders, you-name-it to get together to write code or push pixels. We’ll provide good food, good people, and creative energy.</p> <p>Here’s how OpenHack works:</p> <p>* You can hack on anything! Any language, framework, public/open-source, personal projects, client work… anything!<br/>* You don’t have to have an idea to hack on, you can come join someone else<br/>* We’ll kick things off with a quick round of introductions, to say who you are, what you’re working on, and if you’d like help with your idea<br/>* Food and drinks will be provided<br/>* Feel free to join us - bring a laptop, a project, and a friend!</p> <p>See more at <a href=\"http://openhacksyr.com\" class=\"linkified\">http://openhacksyr.com</a></p> <p>• What to bring<br/>A laptop if you're bringing a project, but not required</p> <p>• Important to know<br/>Please review our Code of Conduct before attending: <a href=\"http://openhacksyr.com/code_of_conduct/\" class=\"linkified\">http://openhacksyr.com/code_of_conduct/</a></p> "
+  },
+  {
+    "name": "Syracuse JavaScript Meetup | Topic: TBD",
+    "local_date": "2020-08-18",
+    "local_time": "18:00",
+    "link": "https://www.meetup.com/Syracuse-Software-Development-Meetup/events/jccphrybclbxb/",
+    "description": "<p>We are a group dedicated to discussing and working with the JavaScript programming language.</p> <p>Currently we meet the third Tuesday of each month, and each event has both a learning and interactive portion. Whether you’re an experienced JavaScript programmer or just getting started, we welcome and encourage all proficiency levels.</p> <p>Each month we'll be exploring the \"Current Topic\" referenced in the Meetup title. If you're not familiar with the topic, come learn something new! Already a pro? Awesome! We can use some mentors to help out with questions. Check us out for some great discussions, food, and drink!</p> <p>• What to bring<br/>Laptop</p> <p>• Important to know<br/>Harassment-free meetup, regardless of topic</p> "
+  },
+  {
+    "name": "OpenHack: Code together, on anything.",
+    "local_date": "2020-09-08",
+    "local_time": "18:00",
+    "link": "https://www.meetup.com/Syracuse-Software-Development-Meetup/events/gdqxgpybcmblb/",
+    "description": "<p>• What we'll do<br/>OpenHack is a casual social coding meetup with a simple purpose: Code together, on anything.</p> <p>We welcome local developers and designers of all skill levels, interests, ages genders, you-name-it to get together to write code or push pixels. We’ll provide good food, good people, and creative energy.</p> <p>Here’s how OpenHack works:</p> <p>* You can hack on anything! Any language, framework, public/open-source, personal projects, client work… anything!<br/>* You don’t have to have an idea to hack on, you can come join someone else<br/>* We’ll kick things off with a quick round of introductions, to say who you are, what you’re working on, and if you’d like help with your idea<br/>* Food and drinks will be provided<br/>* Feel free to join us - bring a laptop, a project, and a friend!</p> <p>See more at <a href=\"http://openhacksyr.com\" class=\"linkified\">http://openhacksyr.com</a></p> <p>• What to bring<br/>A laptop if you're bringing a project, but not required</p> <p>• Important to know<br/>Please review our Code of Conduct before attending: <a href=\"http://openhacksyr.com/code_of_conduct/\" class=\"linkified\">http://openhacksyr.com/code_of_conduct/</a></p> "
+  },
+  {
+    "name": "Women in Coding - Monthly Workshop",
+    "local_date": "2020-09-12",
+    "local_time": "10:00",
+    "link": "https://www.meetup.com/Syracuse-Software-Development-Meetup/events/rbmxbrybcmbqb/",
+    "description": "<p>• What we'll do<br/>Women in Coding will be hosting workshop style classes once a month every second Saturday of the month, from 10am-12pm at The Tech Garden! Rather than having an instructor teach a specific topic, these workshops will give you the chance to work on a project or work through an online curriculum at your own pace. Never coded before? No problem. We'll help get you started. Each workshop will have at least one mentor there to provide support and answer questions.</p> <p>• What to bring<br/>Bring your computer, questions and/or a project</p> <p>• Important to know<br/>This month's mentors and their skills are TBD. Check for updates.</p> <p>Big thank you to Hack Upstate for sponsoring our meetups. You can learn more about them at <a href=\"http://hackupstate.com/\" class=\"linkified\">http://hackupstate.com/</a>.</p> "
+  },
+  {
+    "name": "Syracuse JavaScript Meetup | Topic: TBD",
+    "local_date": "2020-09-15",
+    "local_time": "18:00",
+    "link": "https://www.meetup.com/Syracuse-Software-Development-Meetup/events/jccphrybcmbtb/",
+    "description": "<p>We are a group dedicated to discussing and working with the JavaScript programming language.</p> <p>Currently we meet the third Tuesday of each month, and each event has both a learning and interactive portion. Whether you’re an experienced JavaScript programmer or just getting started, we welcome and encourage all proficiency levels.</p> <p>Each month we'll be exploring the \"Current Topic\" referenced in the Meetup title. If you're not familiar with the topic, come learn something new! Already a pro? Awesome! We can use some mentors to help out with questions. Check us out for some great discussions, food, and drink!</p> <p>• What to bring<br/>Laptop</p> <p>• Important to know<br/>Harassment-free meetup, regardless of topic</p> "
+  },
+  {
+    "name": "Women in Coding - Monthly Workshop",
+    "local_date": "2020-10-10",
+    "local_time": "10:00",
+    "link": "https://www.meetup.com/Syracuse-Software-Development-Meetup/events/rbmxbrybcnbnb/",
+    "description": "<p>• What we'll do<br/>Women in Coding will be hosting workshop style classes once a month every second Saturday of the month, from 10am-12pm at The Tech Garden! Rather than having an instructor teach a specific topic, these workshops will give you the chance to work on a project or work through an online curriculum at your own pace. Never coded before? No problem. We'll help get you started. Each workshop will have at least one mentor there to provide support and answer questions.</p> <p>• What to bring<br/>Bring your computer, questions and/or a project</p> <p>• Important to know<br/>This month's mentors and their skills are TBD. Check for updates.</p> <p>Big thank you to Hack Upstate for sponsoring our meetups. You can learn more about them at <a href=\"http://hackupstate.com/\" class=\"linkified\">http://hackupstate.com/</a>.</p> "
+  },
+  {
+    "name": "OpenHack: Code together, on anything.",
+    "local_date": "2020-10-13",
+    "local_time": "18:00",
+    "link": "https://www.meetup.com/Syracuse-Software-Development-Meetup/events/gdqxgpybcnbrb/",
+    "description": "<p>• What we'll do<br/>OpenHack is a casual social coding meetup with a simple purpose: Code together, on anything.</p> <p>We welcome local developers and designers of all skill levels, interests, ages genders, you-name-it to get together to write code or push pixels. We’ll provide good food, good people, and creative energy.</p> <p>Here’s how OpenHack works:</p> <p>* You can hack on anything! Any language, framework, public/open-source, personal projects, client work… anything!<br/>* You don’t have to have an idea to hack on, you can come join someone else<br/>* We’ll kick things off with a quick round of introductions, to say who you are, what you’re working on, and if you’d like help with your idea<br/>* Food and drinks will be provided<br/>* Feel free to join us - bring a laptop, a project, and a friend!</p> <p>See more at <a href=\"http://openhacksyr.com\" class=\"linkified\">http://openhacksyr.com</a></p> <p>• What to bring<br/>A laptop if you're bringing a project, but not required</p> <p>• Important to know<br/>Please review our Code of Conduct before attending: <a href=\"http://openhacksyr.com/code_of_conduct/\" class=\"linkified\">http://openhacksyr.com/code_of_conduct/</a></p> "
+  }
+]

--- a/src/templates/groupMdxTemplate.js
+++ b/src/templates/groupMdxTemplate.js
@@ -6,13 +6,10 @@ import EventLink from '../components/EventLink'
 import OrganizerSection from '../components/OrganizersSection'
 import styled from 'styled-components'
 
-const EventContainer = styled.p`
-  margin-top: 0;
-  color: #888888;
-  font-size: 14px;
-`
 const ArchivedEventContainer = styled.section`
-  a { font-size: 16px; }
+  a {
+    font-size: 16px;
+  }
 `
 
 function NextMeetup(props) {
@@ -50,14 +47,6 @@ const GroupMDXTemplate = ({ data }) => (
     <MDXRenderer>{data.mdx.code.body}</MDXRenderer>
 
     <NextMeetup data={data} />
-    {data.upcomingMeetup &&
-      data.upcomingMeetup.nodes.length > 0 &&
-      data.upcomingMeetup.nodes[0].rsvp_count && (
-        <EventContainer>
-          {data.upcomingMeetup.nodes[0].rsvp_count} other people are already
-          planning on going...
-        </EventContainer>
-    )}
     {data.mdx.frontmatter.organizers && (
       <OrganizerSection organizers={data.mdx.frontmatter.organizers} />
     )}
@@ -108,7 +97,6 @@ export const PageQuery = graphql`
         name
         local_date(formatString: "MMMM DD, YYYY")
         link
-        rsvp_count
       }
     }
     archivedEvents: allSyrEvent(

--- a/yarn.lock
+++ b/yarn.lock
@@ -5568,14 +5568,6 @@ gatsby-source-filesystem@^2.0.36:
     valid-url "^1.0.9"
     xstate "^3.1.0"
 
-gatsby-source-meetup@^0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/gatsby-source-meetup/-/gatsby-source-meetup-0.0.1.tgz#45f196748c9445a6c4b3a3f8076cd59c156d3f5a"
-  integrity sha512-ZVwML432/L2sMPIsbI8ofdiKnnuMsrpbkRmoz/QuYIL177f/uVvy9xvSoTwaDADFAnuw6XK5Ck/Gg8Fq8AkbVA==
-  dependencies:
-    node-fetch "^2.2.1"
-    query-string "^6.2.0"
-
 gatsby-telemetry@^1.0.9:
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/gatsby-telemetry/-/gatsby-telemetry-1.0.9.tgz#f9192d5bf72fb239d477e9b556a7dc040c4a566b"
@@ -8516,7 +8508,7 @@ node-fetch@2.1.2:
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.1.2.tgz#ab884e8e7e57e38a944753cec706f788d1768bb5"
   integrity sha1-q4hOjn5X44qUR1POxwb3iNF2i7U=
 
-node-fetch@2.3.0, node-fetch@^2.2.1:
+node-fetch@2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.3.0.tgz#1a1d940bbfb916a1d3e0219f037e89e71f8c5fa5"
   integrity sha512-MOd8pV3fxENbryESLgVIeaGKrdl+uaYhCSSVkjeOb/31/njTpcis5aWfdqgNlHIrKOLRbMnfPINPOML2CIFeXA==
@@ -10024,14 +10016,6 @@ query-string@^5.0.1:
     decode-uri-component "^0.2.0"
     object-assign "^4.1.0"
     strict-uri-encode "^1.0.0"
-
-query-string@^6.2.0:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/query-string/-/query-string-6.2.0.tgz#468edeb542b7e0538f9f9b1aeb26f034f19c86e1"
-  integrity sha512-5wupExkIt8RYL4h/FE+WTg3JHk62e6fFPWtAZA9J5IWK1PfTfKkMS93HBUHcFpeYi9KsY5pFbh+ldvEyaz5MyA==
-  dependencies:
-    decode-uri-component "^0.2.0"
-    strict-uri-encode "^2.0.0"
 
 querystring-es3@^0.2.0:
   version "0.2.1"
@@ -11562,11 +11546,6 @@ strict-uri-encode@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
   integrity sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=
-
-strict-uri-encode@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz#b9c7330c7042862f6b142dc274bbcc5866ce3546"
-  integrity sha1-ucczDHBChi9rFC3CdLvMWGbONUY=
 
 string-similarity@^1.2.0:
   version "1.2.2"


### PR DESCRIPTION
Due to the situation where Meetup's API is now not available without a pro network as well as the thing where you may have to pay for RSVPs in the future, we decided upon starting to get away from Meetup.

@vormwald downloaded the data from meetup.com (all past events and all scheduled future  events until Oct 2020) and then I reformatted it so it suits our current data model.